### PR TITLE
feat(release): v1.2.11 — Supabase edge function elimination + arch refactor

### DIFF
--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -5,7 +5,7 @@
 library;
 
 /// App version string (semver). Must match pubspec.yaml.
-const appVersion = '1.2.10';
+const appVersion = '1.2.11';
 
 /// App name for display.
 const appName = 'WhisPaste';

--- a/lib/core/config/settings_provider.dart
+++ b/lib/core/config/settings_provider.dart
@@ -521,77 +521,139 @@ class AppSettings {
   }
 
   /// Serializes settings into a string map for SQLite persistence.
-  Map<String, String> toStorageMap() {
-    return {
-      'theme_mode': themeMode.name,
-      'locale': locale,
-      'launch_at_startup': '$launchAtStartup',
-      'start_minimized': '$startMinimized',
-      'show_notifications': '$showNotifications',
-      'microphone': microphone,
-      'input_gain': '$inputGain',
-      'push_to_talk': '$pushToTalk',
-      'dead_mic_timeout': '$deadMicTimeout',
-      'auto_stop_silence': '$autoStopSilence',
-      'stt_provider': sttProvider,
-      'stt_model': sttModel,
-      'stt_language': sttLanguage,
-      'stt_idle_timeout_minutes': '$sttIdleTimeoutMinutes',
-      'custom_vocabulary': customVocabulary,
-      'record_start_sound': '$recordStartSound',
-      'record_stop_sound': '$recordStopSound',
-      'transcription_complete_sound': '$transcriptionCompleteSound',
-      'duration_warning_sound': '$durationWarningSound',
-      'sound_volume': '$soundVolume',
-      'after_transcription': afterTranscription,
-      'show_overlay': '$showOverlay',
-      'overlay_mode': overlayMode,
-      'overlay_start_position': overlayStartPosition,
-      'overlay_size': overlaySize,
-      'overlay_auto_hide': overlayAutoHide,
-      'show_floating_button': '$showFloatingButton',
-      'floating_button_opacity': '$floatingButtonOpacity',
-      'floating_button_size': floatingButtonSize,
-      'floating_overlay_opacity': '$floatingOverlayOpacity',
-      // API keys are stored in secure storage — never persist to SQLite.
-      'openai_api_key': '',
-      'groq_api_key': '',
-      'deepgram_api_key': '',
-      'anthropic_api_key': '',
-      'gemini_api_key': '',
-      'cloud_stt_provider': cloudSttProvider,
-      'max_record_duration': '$maxRecordDuration',
-      'close_to_tray': '$closeToTray',
-      'error_reporting': '$errorReporting',
-      'gpu_acceleration': gpuAcceleration,
-      'auto_paste_delay': '$autoPasteDelay',
-      'auto_paste_blocklist': autoPasteBlocklist,
-      'trim_silence': '$trimSilence',
-      'use_vad': '$useVAD',
-      'vad_sensitivity': '$vadSensitivity',
-      'text_replacements_enabled': '$textReplacementsEnabled',
-      'check_updates': '$checkUpdates',
-      'history_max_entries': '$historyMaxEntries',
-      'history_auto_trash_days': '$historyAutoTrashDays',
-      'hotkey_enabled': '$hotkeyEnabled',
-      'hotkey_key': hotkeyKey,
-      'hotkey_modifiers': hotkeyModifiers,
-      'floating_button_x': '$floatingButtonX',
-      'floating_button_y': '$floatingButtonY',
-      'floating_overlay_x': '$floatingOverlayX',
-      'floating_overlay_y': '$floatingOverlayY',
-      'window_x': '$windowX',
-      'window_y': '$windowY',
-      'window_width': '$windowWidth',
-      'window_height': '$windowHeight',
-      'window_maximized': '$windowMaximized',
-      'onboarding_completed': '$onboardingCompleted',
-      // Benchmark data
-      'tier_benchmark_rtf': _writeBenchmarkRtf(tierBenchmarkRtf),
-      'benchmark_hardware_id': benchmarkHardwareId ?? '',
-      'benchmark_timestamp': benchmarkTimestamp?.toIso8601String() ?? '',
-    };
-  }
+  Map<String, String> toStorageMap() => {
+    'schema_version': '2',
+    ..._interfaceToMap(),
+    ..._audioToMap(),
+    ..._recordingSafetyToMap(),
+    ..._sttToMap(),
+    ..._soundToMap(),
+    ..._afterTranscriptionToMap(),
+    ..._overlayToMap(),
+    ..._cloudProvidersToMap(),
+    ..._behaviorToMap(),
+    ..._audioProcessingToMap(),
+    ..._updatesToMap(),
+    ..._historyToMap(),
+    ..._hotkeyToMap(),
+    ..._windowToMap(),
+    ..._onboardingToMap(),
+    ..._benchmarkToMap(),
+  };
+
+  Map<String, String> _interfaceToMap() => {
+    'theme_mode': themeMode.name,
+    'locale': locale,
+    'launch_at_startup': '$launchAtStartup',
+    'start_minimized': '$startMinimized',
+    'show_notifications': '$showNotifications',
+  };
+
+  Map<String, String> _audioToMap() => {
+    'microphone': microphone,
+    'input_gain': '$inputGain',
+    'push_to_talk': '$pushToTalk',
+  };
+
+  Map<String, String> _recordingSafetyToMap() => {
+    'dead_mic_timeout': '$deadMicTimeout',
+    'auto_stop_silence': '$autoStopSilence',
+  };
+
+  Map<String, String> _sttToMap() => {
+    'stt_provider': sttProvider,
+    'stt_model': sttModel,
+    'stt_language': sttLanguage,
+    'stt_idle_timeout_minutes': '$sttIdleTimeoutMinutes',
+    'custom_vocabulary': customVocabulary,
+  };
+
+  Map<String, String> _soundToMap() => {
+    'record_start_sound': '$recordStartSound',
+    'record_stop_sound': '$recordStopSound',
+    'transcription_complete_sound': '$transcriptionCompleteSound',
+    'duration_warning_sound': '$durationWarningSound',
+    'sound_volume': '$soundVolume',
+  };
+
+  Map<String, String> _afterTranscriptionToMap() => {
+    'after_transcription': afterTranscription,
+  };
+
+  Map<String, String> _overlayToMap() => {
+    'show_overlay': '$showOverlay',
+    'overlay_mode': overlayMode,
+    'overlay_start_position': overlayStartPosition,
+    'overlay_size': overlaySize,
+    'overlay_auto_hide': overlayAutoHide,
+    'show_floating_button': '$showFloatingButton',
+    'floating_button_opacity': '$floatingButtonOpacity',
+    'floating_button_size': floatingButtonSize,
+    'floating_overlay_opacity': '$floatingOverlayOpacity',
+  };
+
+  Map<String, String> _cloudProvidersToMap() => {
+    // API keys are stored in secure storage — never persist to SQLite.
+    'openai_api_key': '',
+    'groq_api_key': '',
+    'deepgram_api_key': '',
+    'anthropic_api_key': '',
+    'gemini_api_key': '',
+    'cloud_stt_provider': cloudSttProvider,
+  };
+
+  Map<String, String> _behaviorToMap() => {
+    'max_record_duration': '$maxRecordDuration',
+    'close_to_tray': '$closeToTray',
+    'error_reporting': '$errorReporting',
+    'gpu_acceleration': gpuAcceleration,
+    'auto_paste_delay': '$autoPasteDelay',
+    'auto_paste_blocklist': autoPasteBlocklist,
+  };
+
+  Map<String, String> _audioProcessingToMap() => {
+    'trim_silence': '$trimSilence',
+    'use_vad': '$useVAD',
+    'vad_sensitivity': '$vadSensitivity',
+    'text_replacements_enabled': '$textReplacementsEnabled',
+  };
+
+  Map<String, String> _updatesToMap() => {
+    'check_updates': '$checkUpdates',
+  };
+
+  Map<String, String> _historyToMap() => {
+    'history_max_entries': '$historyMaxEntries',
+    'history_auto_trash_days': '$historyAutoTrashDays',
+  };
+
+  Map<String, String> _hotkeyToMap() => {
+    'hotkey_enabled': '$hotkeyEnabled',
+    'hotkey_key': hotkeyKey,
+    'hotkey_modifiers': hotkeyModifiers,
+  };
+
+  Map<String, String> _windowToMap() => {
+    'floating_button_x': '$floatingButtonX',
+    'floating_button_y': '$floatingButtonY',
+    'floating_overlay_x': '$floatingOverlayX',
+    'floating_overlay_y': '$floatingOverlayY',
+    'window_x': '$windowX',
+    'window_y': '$windowY',
+    'window_width': '$windowWidth',
+    'window_height': '$windowHeight',
+    'window_maximized': '$windowMaximized',
+  };
+
+  Map<String, String> _onboardingToMap() => {
+    'onboarding_completed': '$onboardingCompleted',
+  };
+
+  Map<String, String> _benchmarkToMap() => {
+    'tier_benchmark_rtf': _writeBenchmarkRtf(tierBenchmarkRtf),
+    'benchmark_hardware_id': benchmarkHardwareId ?? '',
+    'benchmark_timestamp': benchmarkTimestamp?.toIso8601String() ?? '',
+  };
 
   AppSettings copyWith({
     ThemeMode? themeMode,

--- a/lib/services/drift_recording_store.dart
+++ b/lib/services/drift_recording_store.dart
@@ -1,0 +1,89 @@
+import 'dart:math' as math;
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/data/database.dart';
+import 'recording_store.dart';
+
+/// [RecordingStore] backed by the Drift SQLite database.
+class DriftRecordingStore implements RecordingStore {
+  const DriftRecordingStore(this._db);
+
+  final HistoryDatabase _db;
+
+  @override
+  Future<SavedRecording> save(RecordingInput input) async {
+    final now = DateTime.now();
+    final id =
+        '${now.millisecondsSinceEpoch}-'
+        '${math.Random().nextInt(9999).toString().padLeft(4, '0')}';
+
+    // 1. Apply text replacements (best-effort; non-fatal if it fails).
+    var processedTranscript = input.transcript;
+    if (input.applyTextReplacements) {
+      try {
+        final replacements = await _db.readAllReplacements();
+        for (final r in replacements) {
+          final escaped = RegExp.escape(r.trigger);
+          final pattern = RegExp(
+            r'(?<=\s|^)' + escaped + r'(?=\s|$|[.,;:!?])',
+            caseSensitive: false,
+          );
+          processedTranscript =
+              processedTranscript.replaceAll(pattern, r.replacement);
+        }
+      } on Exception {
+        // Non-fatal: save raw transcript if replacements fail.
+        processedTranscript = input.transcript;
+      }
+    }
+
+    // 2. Derive title (first 60 chars of processed transcript).
+    final title = processedTranscript.length > 60
+        ? '${processedTranscript.substring(0, 60)}…'
+        : processedTranscript;
+
+    // 3. Save history entry.
+    await _db.upsertEntry(
+      HistoryEntriesCompanion(
+        id: Value(id),
+        content: Value(processedTranscript),
+        title: Value(title),
+        timestamp: Value(now),
+        durationSec: Value(input.audioDuration.inSeconds.toDouble()),
+        language: Value(input.languageCode),
+        model: Value(input.modelId),
+        isLocal: Value(input.isLocal),
+        source: const Value('dictation'),
+      ),
+    );
+
+    // 4. Record daily stat.
+    await _db.recordDailyStat(
+      timestamp: now,
+      model: input.modelId,
+      isLocal: input.isLocal,
+      durationSec: input.audioDuration.inSeconds.toDouble(),
+      processingDurationSec: input.processingDurationSec.toDouble(),
+      wordCount: input.wordCount,
+      costUsd: 0,
+    );
+
+    // 5. Trim to max entries (0 = unlimited).
+    final trimmedCount = input.historyMaxEntries > 0
+        ? await _db.trimToMaxEntries(input.historyMaxEntries)
+        : 0;
+
+    return SavedRecording(
+      entryId: id,
+      processedTranscript: processedTranscript,
+      trimmedCount: trimmedCount,
+    );
+  }
+}
+
+final recordingStoreProvider = Provider<RecordingStore>((ref) {
+  final db = ref.watch(historyDatabaseProvider);
+  return DriftRecordingStore(db);
+});

--- a/lib/services/paste/desktop_paster.dart
+++ b/lib/services/paste/desktop_paster.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../desktop_paste/desktop_paste_controller.dart';
+import 'paster.dart';
+
+/// [Paster] implementation for Windows and macOS using [DesktopPasteController].
+///
+/// Implements the full paste lifecycle:
+/// - Blocklist check via bundle ID
+/// - Clipboard save → set transcript → native paste → wait → clipboard restore
+class DesktopPaster implements Paster {
+  const DesktopPaster(this._controller);
+
+  final DesktopPasteController _controller;
+
+  @override
+  Future<void> prime() async {
+    try {
+      await _controller.capturePasteTarget();
+    } on MissingPluginException {
+      // Not available in test environments — silently degrade.
+    }
+  }
+
+  @override
+  Future<PasteOutcome> paste(String text, PasteOptions options) async {
+    // 1. Blocklist check
+    final blocklist = options.blocklist.trim();
+    if (blocklist.isNotEmpty) {
+      try {
+        final targetId = await _controller.getTargetBundleId();
+        if (targetId != null && targetId.isNotEmpty) {
+          final blocked = blocklist
+              .split(',')
+              .map((e) => e.trim().toLowerCase())
+              .where((e) => e.isNotEmpty)
+              .toSet();
+          if (blocked.contains(targetId.toLowerCase())) {
+            return PasteOutcome.blocked;
+          }
+        }
+      } on MissingPluginException {
+        // Bundle ID lookup unsupported — skip blocklist.
+      }
+    }
+
+    // 2. Save current clipboard contents so we can restore after paste.
+    String? previousClipboard;
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain).timeout(
+        const Duration(seconds: 2),
+      );
+      previousClipboard = data?.text;
+    } on Exception {
+      // Best-effort snapshot; failure here is non-fatal.
+    }
+
+    // 3. Write transcript to clipboard.
+    try {
+      await Clipboard.setData(ClipboardData(text: text)).timeout(
+        const Duration(seconds: 5),
+      );
+    } on Exception {
+      return PasteOutcome.failed;
+    }
+
+    // 4. Trigger native paste shortcut.
+    final delay = Duration(milliseconds: options.autoPasteDelayMs);
+    bool pasted = false;
+    try {
+      pasted = await _controller.pasteClipboard(delay: delay);
+    } on MissingPluginException {
+      return PasteOutcome.platformUnavailable;
+    } on Exception {
+      return PasteOutcome.failed;
+    }
+
+    if (!pasted) return PasteOutcome.failed;
+
+    // 5. Wait before restoring clipboard so the paste has time to land.
+    await Future<void>.delayed(delay);
+
+    // 6. Restore previous clipboard contents.
+    try {
+      await Clipboard.setData(ClipboardData(text: previousClipboard ?? ''))
+          .timeout(const Duration(seconds: 5));
+    } on Exception {
+      // Non-fatal — clipboard restore is best-effort.
+    }
+
+    return PasteOutcome.success;
+  }
+
+}
+
+final pasterProvider = Provider<Paster?>((ref) {
+  final controller = ref.watch(desktopPasteControllerProvider);
+  if (controller == null) return null;
+  return DesktopPaster(controller);
+});

--- a/lib/services/paste/paster.dart
+++ b/lib/services/paste/paster.dart
@@ -1,0 +1,51 @@
+/// Deep abstraction over "write text to the active window".
+///
+/// [RecordingOrchestrator] calls [prime] before recording starts (to capture
+/// the target window) and [paste] after transcription. All timing, clipboard
+/// management, and blocklist logic are hidden behind this interface.
+library;
+
+export 'desktop_paster.dart';
+
+/// The outcome of a paste operation.
+enum PasteOutcome {
+  /// Text was successfully pasted into the target window.
+  success,
+
+  /// The target app is on the auto-paste blocklist.
+  blocked,
+
+  /// Platform paste bridge not available (unsupported OS / test env).
+  platformUnavailable,
+
+  /// Paste was attempted but the native bridge reported failure.
+  failed,
+}
+
+/// Configuration for a paste operation, derived from [AppSettings].
+class PasteOptions {
+  const PasteOptions({
+    required this.autoPasteDelayMs,
+    required this.blocklist,
+  });
+
+  /// User-configured delay before pasting (milliseconds).
+  final int autoPasteDelayMs;
+
+  /// Comma-separated list of app bundle IDs / process names to skip.
+  final String blocklist;
+}
+
+/// Manages the full "write text to active window" lifecycle.
+abstract class Paster {
+  /// Captures the paste target window before recording starts.
+  ///
+  /// Must be called before [paste]. On platforms without a native bridge,
+  /// this is a no-op.
+  Future<void> prime();
+
+  /// Writes [text] to the previously captured window.
+  ///
+  /// Handles clipboard save/restore, delay timing, and blocklist check.
+  Future<PasteOutcome> paste(String text, PasteOptions options);
+}

--- a/lib/services/process_runner.dart
+++ b/lib/services/process_runner.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+/// Injectable abstraction over [Process.start].
+///
+/// Exists solely to make [SttServiceNotifier._start] testable without
+/// spawning a real subprocess. The system implementation delegates directly;
+/// tests supply a fake.
+abstract class ProcessRunner {
+  const ProcessRunner();
+
+  Future<Process> start(String executable, List<String> arguments);
+}
+
+class SystemProcessRunner extends ProcessRunner {
+  const SystemProcessRunner();
+
+  @override
+  Future<Process> start(String executable, List<String> arguments) =>
+      Process.start(executable, arguments, mode: ProcessStartMode.normal);
+}

--- a/lib/services/recording_orchestrator.dart
+++ b/lib/services/recording_orchestrator.dart
@@ -7,26 +7,25 @@ library;
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:math' as math;
 
-import 'package:drift/drift.dart' show Value;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 
 import '../core/config/settings_enums.dart';
 import '../core/config/settings_provider.dart';
-import '../core/data/database.dart';
 import '../core/logging/app_logger.dart';
 import '../core/recording/recording_state.dart';
 import '../core/data/analytics_provider.dart';
 import 'audio_service.dart';
-import 'desktop_paste/desktop_paste_controller.dart';
 import 'model_download_service.dart';
 import 'path_service.dart';
 import 'review_prompt_service.dart';
 import 'sound_feedback_service.dart';
+import 'paste/paster.dart';
+import 'recording_store.dart';
 import 'stt_service.dart';
+import 'transcription/transcriber.dart';
 
 // ---------------------------------------------------------------------------
 // Orchestrator
@@ -71,9 +70,6 @@ class RecordingOrchestrator extends Notifier<void> {
 
   /// Whether the 90% duration warning has been played.
   bool _durationWarningFired = false;
-
-  /// Whether the current recording session has a captured desktop paste target.
-  bool _hasCapturedPasteTarget = false;
 
   int _oomAttemptCount = 0;
 
@@ -149,7 +145,7 @@ class RecordingOrchestrator extends Notifier<void> {
       // Fires before the two async calls below to maximise warm-up lead time.
       unawaited(sttNot.ensureRunning());
 
-      _hasCapturedPasteTarget = await _capturePasteTarget();
+      await ref.read(pasterProvider)?.prime();
 
       // Start audio capture.
       final audioNotifier = ref.read(audioServiceProvider.notifier);
@@ -285,24 +281,29 @@ class RecordingOrchestrator extends Notifier<void> {
         effectiveLang = appLocale; // e.g. "de", "en"
       }
 
-      // Ensure STT server is ready (with generous timeout for cold-starts —
+      // Ensure STT backend is ready (with generous timeout for cold-starts —
       // large models on integrated GPUs can take 60–90s to load into VRAM).
-      final sttNotifier = ref.read(sttServiceProvider.notifier);
+      final transcriber = ref.read(transcriberProvider);
       final ensureSw = Stopwatch()..start();
       try {
-        await sttNotifier.ensureRunning().timeout(const Duration(seconds: 120));
+        await transcriber.prepare().timeout(const Duration(seconds: 120));
       } on TimeoutException {
         pipelineOutcome = 'stt_timeout';
         notifier.fail('stt_start_timeout');
         _log.warning('[$sid] STT server start timed out after 120s');
         return;
+      } on TranscriberException catch (e) {
+        pipelineOutcome = 'stt_start_error';
+        notifier.fail(e.message);
+        _log.warning('[$sid] STT prepare failed: ${e.message}');
+        return;
       }
       ensureSw.stop();
       sttEnsureMs = ensureSw.elapsedMilliseconds;
 
-      // Verify server is ready before transcribing.
+      // Verify local server is ready before transcribing (on-device only).
       final sttStatus = ref.read(sttServiceProvider);
-      if (!sttStatus.isReady) {
+      if (!sttStatus.isReady && settings.sttProviderType.isLocal) {
         if (sttStatus.errorMessage == 'stt_cuda_oom') {
           pipelineOutcome = 'stt_cuda_oom';
           _handleOomRecovery();
@@ -328,8 +329,8 @@ class RecordingOrchestrator extends Notifier<void> {
       final timeoutSec = 60 + (audioDurMs / 1000 * 0.8).round();
       String transcript;
       try {
-        transcript = await sttNotifier
-            .transcribeBytes(wavBytes, language: effectiveLang)
+        transcript = await transcriber
+            .transcribe(wavBytes, language: effectiveLang)
             .timeout(Duration(seconds: timeoutSec));
       } on TimeoutException {
         pipelineOutcome = 'transcribe_timeout';
@@ -360,6 +361,11 @@ class RecordingOrchestrator extends Notifier<void> {
           '[$sid] STT server connection lost during inference (ClientException)',
         );
         return;
+      } on TranscriberException catch (e) {
+        pipelineOutcome = 'transcribe_error';
+        notifier.fail(e.message);
+        _log.error('[$sid] Transcription failed: ${e.message}');
+        return;
       }
       inferSw.stop();
       transcribeMs = inferSw.elapsedMilliseconds;
@@ -378,34 +384,9 @@ class RecordingOrchestrator extends Notifier<void> {
         return;
       }
 
-      // ── Text replacements (voice shortcuts) ─────────────────────────────
+      // ── Transcription cleanup (always applied) ──────────────────────────
       final replaceSw = Stopwatch()..start();
       var finalText = transcript;
-      if (settings.textReplacementsEnabled) {
-        try {
-          final db = ref.read(historyDatabaseProvider);
-          final replacements = await db.readAllReplacements();
-          if (replacements.isNotEmpty) {
-            for (final r in replacements) {
-              // Case-insensitive whole-word replacement.
-              final escaped = RegExp.escape(r.trigger);
-              final pattern = RegExp(
-                r'(?<=\s|^)' + escaped + r'(?=\s|$|[.,;:!?])',
-                caseSensitive: false,
-              );
-              finalText = finalText.replaceAll(pattern, r.replacement);
-            }
-            if (finalText != transcript) {
-              _log.info(
-                '[$sid] Text replacements applied: ${replacements.length} rules, '
-                '${transcript.length}→${finalText.length} chars',
-              );
-            }
-          }
-        } on Exception catch (e) {
-          _log.warning('[$sid] Text replacement failed (non-fatal): $e');
-        }
-      }
       replaceSw.stop();
       replaceMs = replaceSw.elapsedMilliseconds;
 
@@ -426,9 +407,19 @@ class RecordingOrchestrator extends Notifier<void> {
 
       // Save to history database (with replacements applied).
       final saveSw = Stopwatch()..start();
-      await _saveToHistory(finalText, settings);
+      final savedTranscript = await _saveToHistory(
+        finalText,
+        Duration(milliseconds: audioDurMs),
+        settings,
+        transcribeMs ~/ 1000,
+      );
       saveSw.stop();
       saveMs = saveSw.elapsedMilliseconds;
+
+      // Use the processed transcript (after replacements) for paste.
+      if (savedTranscript != null && savedTranscript != finalText) {
+        finalText = savedTranscript;
+      }
 
       // Copy to clipboard / auto-paste based on user preference.
       // Timeout prevents a locked clipboard from hanging the pipeline.
@@ -707,68 +698,49 @@ class RecordingOrchestrator extends Notifier<void> {
     return null;
   }
 
-  Future<void> _saveToHistory(String transcript, AppSettings settings) async {
-    final db = ref.read(historyDatabaseProvider);
-    final now = DateTime.now();
-    final recording = ref.read(recordingProvider);
+  Future<String?> _saveToHistory(
+    String transcript,
+    Duration audioDuration,
+    AppSettings settings,
+    int processingDurationSec,
+  ) async {
+    try {
+      final store = ref.read(recordingStoreProvider);
+      final wordCount = transcript.trim().isEmpty
+          ? 0
+          : transcript.trim().split(RegExp(r'\s+')).length;
 
-    final id = '${now.millisecondsSinceEpoch}';
-    final durationSec = recording.elapsed.inSeconds.toDouble();
+      final saved = await store.save(
+        RecordingInput(
+          transcript: transcript,
+          audioDuration: audioDuration,
+          modelId: settings.effectiveModelId,
+          isLocal: settings.sttProviderType.isLocal,
+          languageCode: settings.sttLanguageCode,
+          applyTextReplacements: settings.textReplacementsEnabled,
+          historyMaxEntries: settings.historyMaxEntries,
+          wordCount: wordCount,
+          processingDurationSec: processingDurationSec,
+        ),
+      );
 
-    // Auto-generate a short title from the first ~60 chars.
-    var title = transcript.trim();
-    if (title.length > 60) {
-      // Cut at the last word boundary within 60 chars.
-      final cut = title.substring(0, 60);
-      final lastSpace = cut.lastIndexOf(' ');
-      title = lastSpace > 20 ? '${cut.substring(0, lastSpace)}…' : '$cut…';
-    }
+      _log.info('Saved entry ${saved.entryId} to history');
 
-    final wordCount = transcript.trim().isEmpty
-        ? 0
-        : transcript.trim().split(RegExp(r'\s+')).length;
-
-    await db.upsertEntry(
-      HistoryEntriesCompanion(
-        id: Value(id),
-        content: Value(transcript),
-        title: Value(title),
-        timestamp: Value(now),
-        durationSec: Value(durationSec),
-        language: Value(settings.sttLanguageCode),
-        model: Value(settings.effectiveModelId),
-        isLocal: const Value(true),
-        source: const Value('dictation'),
-      ),
-    );
-
-    // Persist analytics independently from history — these counters survive
-    // history entry deletion.
-    await db.recordDailyStat(
-      timestamp: now,
-      model: settings.effectiveModelId,
-      isLocal: true,
-      durationSec: durationSec,
-      processingDurationSec: 0,
-      wordCount: wordCount,
-      costUsd: 0,
-    );
-
-    _log.info('Saved entry $id to history');
-
-    // Auto-cleanup: trim oldest non-favorite entries if limit is set.
-    if (settings.historyMaxEntries > 0) {
-      final trimmed = await db.trimToMaxEntries(settings.historyMaxEntries);
-      if (trimmed > 0) {
+      if (saved.trimmedCount > 0) {
         _log.info(
-          'Auto-trimmed $trimmed old entries to stay within '
+          'Auto-trimmed ${saved.trimmedCount} old entries to stay within '
           '${settings.historyMaxEntries} limit',
         );
       }
-    }
 
-    // Refresh analytics dashboard so counters update immediately.
-    ref.invalidate(analyticsProvider);
+      // Refresh analytics dashboard so counters update immediately.
+      ref.invalidate(analyticsProvider);
+
+      return saved.processedTranscript;
+    } on Exception catch (e) {
+      _log.error('Failed to save to history: $e');
+      return null;
+    }
   }
 
   void _cancelAmplitude() {
@@ -912,39 +884,6 @@ class RecordingOrchestrator extends Notifier<void> {
     }
   }
 
-  Future<bool> _capturePasteTarget() async {
-    final controller = ref.read(desktopPasteControllerProvider);
-    if (controller == null) return false;
-
-    try {
-      return await controller.capturePasteTarget();
-    } on MissingPluginException {
-      _log.warning(
-        'Desktop paste controller missing native implementation for this platform',
-      );
-      return false;
-    } on Exception catch (e) {
-      _log.warning('Paste target capture failed: $e');
-      return false;
-    }
-  }
-
-  Future<String?> _captureClipboardText() async {
-    try {
-      final data = await Clipboard.getData(Clipboard.kTextPlain).timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          _log.warning('Clipboard.getData timed out after 2s');
-          return null;
-        },
-      );
-      return data?.text;
-    } on Exception catch (e) {
-      _log.warning('Clipboard snapshot failed: $e');
-      return null;
-    }
-  }
-
   Future<bool> _copyTranscriptToClipboard(String transcript) async {
     try {
       await Clipboard.setData(ClipboardData(text: transcript)).timeout(
@@ -958,89 +897,6 @@ class RecordingOrchestrator extends Notifier<void> {
     } on Exception catch (e) {
       _log.warning('Clipboard copy failed: $e');
       return false;
-    }
-  }
-
-  Future<bool> _pasteClipboard(AppSettings settings) async {
-    final controller = ref.read(desktopPasteControllerProvider);
-    if (controller == null) {
-      _log.warning(
-        'Auto-paste requested but no desktop paste controller is available',
-      );
-      return false;
-    }
-
-    final delayMs = settings.autoPasteDelay < 0 ? 0 : settings.autoPasteDelay;
-
-    try {
-      if (!_hasCapturedPasteTarget) {
-        _hasCapturedPasteTarget = await _capturePasteTarget();
-      }
-      if (!_hasCapturedPasteTarget) {
-        _log.warning(
-          'Auto-paste requested but no target window could be captured',
-        );
-        return false;
-      }
-
-      // Check per-app auto-paste blocklist
-      final blocklist = settings.autoPasteBlocklist.trim();
-      if (blocklist.isNotEmpty) {
-        try {
-          final targetId = await controller.getTargetBundleId();
-          if (targetId != null && targetId.isNotEmpty) {
-            final blocked = blocklist
-                .split(',')
-                .map((e) => e.trim().toLowerCase())
-                .where((e) => e.isNotEmpty)
-                .toSet();
-            if (blocked.contains(targetId.toLowerCase())) {
-              _log.info(
-                'Auto-paste blocked for app: $targetId (in blocklist)',
-              );
-              return false;
-            }
-          }
-        } on MissingPluginException {
-          // getTargetBundleId not implemented on this platform — skip check
-        }
-      }
-
-      final didPaste = await controller.pasteClipboard(
-        delay: Duration(milliseconds: delayMs),
-      );
-      if (!didPaste) {
-        _log.warning(
-          'Desktop paste bridge reported an unsuccessful paste attempt',
-        );
-      }
-      return didPaste;
-    } on MissingPluginException {
-      _log.warning(
-        'Desktop paste controller missing native implementation for this platform',
-      );
-      return false;
-    } on Exception catch (e) {
-      _log.warning('Desktop paste failed: $e');
-      return false;
-    }
-  }
-
-  Duration _clipboardRestoreDelay(AppSettings settings) {
-    final restoreMs = math.max(500, settings.autoPasteDelay + 350);
-    return Duration(milliseconds: restoreMs);
-  }
-
-  Future<void> _restoreClipboardText(String? previousText) async {
-    try {
-      await Clipboard.setData(ClipboardData(text: previousText ?? '')).timeout(
-        const Duration(seconds: 5),
-        onTimeout: () {
-          _log.warning('Clipboard restore timed out after 5s');
-        },
-      );
-    } on Exception catch (e) {
-      _log.warning('Clipboard restore failed: $e');
     }
   }
 
@@ -1059,21 +915,44 @@ class RecordingOrchestrator extends Notifier<void> {
         await _copyTranscriptToClipboard(transcript);
         return;
       case AfterTranscriptionAction.paste:
-        final previousClipboardText = await _captureClipboardText();
-        final copied = await _copyTranscriptToClipboard(transcript);
-        if (!copied) return;
-
-        final didPaste = await _pasteClipboard(settings);
-        if (didPaste) {
-          await Future<void>.delayed(_clipboardRestoreDelay(settings));
-          await _restoreClipboardText(previousClipboardText);
-        }
+        await _pasteTranscript(transcript, settings);
         return;
       case AfterTranscriptionAction.clipboardAndPaste:
-        final copied = await _copyTranscriptToClipboard(transcript);
-        if (!copied) return;
-        await _pasteClipboard(settings);
+        await _copyTranscriptToClipboard(transcript);
+        await _pasteTranscript(transcript, settings);
         return;
+    }
+  }
+
+  Future<bool> _pasteTranscript(String transcript, AppSettings settings) async {
+    final paster = ref.read(pasterProvider);
+    if (paster == null) return false;
+
+    // Capture the paste target if it hasn't been primed yet (e.g. when this
+    // is the first recording, or recording was started externally).
+    await paster.prime();
+
+    final outcome = await paster.paste(
+      transcript,
+      PasteOptions(
+        autoPasteDelayMs: settings.autoPasteDelay,
+        blocklist: settings.autoPasteBlocklist,
+      ),
+    );
+
+    switch (outcome) {
+      case PasteOutcome.success:
+        _log.info('Pasted transcript (${transcript.length} chars)');
+        return true;
+      case PasteOutcome.blocked:
+        _log.info('Auto-paste blocked for current app (in blocklist)');
+        return false;
+      case PasteOutcome.platformUnavailable:
+        _log.warning('Desktop paste not available on this platform');
+        return false;
+      case PasteOutcome.failed:
+        _log.warning('Paste failed');
+        return false;
     }
   }
 }

--- a/lib/services/recording_store.dart
+++ b/lib/services/recording_store.dart
@@ -1,0 +1,58 @@
+/// Seam for the post-transcription write path.
+///
+/// Encapsulates the four DB operations [RecordingOrchestrator] performs after
+/// a successful transcription: apply text replacements, save history entry,
+/// record daily stat, trim to max entries.
+library;
+
+export 'drift_recording_store.dart';
+
+/// Input to [RecordingStore.save].
+class RecordingInput {
+  const RecordingInput({
+    required this.transcript,
+    required this.audioDuration,
+    required this.modelId,
+    required this.isLocal,
+    required this.languageCode,
+    required this.applyTextReplacements,
+    required this.historyMaxEntries,
+    required this.wordCount,
+    required this.processingDurationSec,
+  });
+
+  final String transcript;
+  final Duration audioDuration;
+  final String modelId;
+  final bool isLocal;
+  final String languageCode;
+  final bool applyTextReplacements;
+
+  /// 0 = unlimited.
+  final int historyMaxEntries;
+  final int wordCount;
+  final int processingDurationSec;
+}
+
+/// Result of [RecordingStore.save].
+class SavedRecording {
+  const SavedRecording({
+    required this.entryId,
+    required this.processedTranscript,
+    required this.trimmedCount,
+  });
+
+  final String entryId;
+
+  /// Transcript after text replacements were applied.
+  final String processedTranscript;
+
+  /// Number of old entries soft-deleted to stay within
+  /// [RecordingInput.historyMaxEntries].
+  final int trimmedCount;
+}
+
+/// Saves a completed transcription to the history database.
+abstract class RecordingStore {
+  Future<SavedRecording> save(RecordingInput input);
+}

--- a/lib/services/stt_service.dart
+++ b/lib/services/stt_service.dart
@@ -19,6 +19,7 @@ import '../core/recording/recording_state.dart' show SttServerState;
 import 'hardware_info_service.dart' as hw;
 import 'model_download_service.dart';
 import 'path_service.dart';
+import 'process_runner.dart';
 import 'subprocess_guard.dart' as guard;
 
 // Re-export so existing importers of stt_service.dart still see SttServerState.
@@ -155,10 +156,16 @@ class SttServiceNotifier extends Notifier<SttStatus> {
 
   /// Reusable HTTP client with connection pooling (mirrors Go's
   /// `sttInferenceClient`). Localhost — no compression needed.
-  final http.Client _httpClient = http.Client();
+  late final http.Client _httpClient;
+
+  /// Injectable process runner for the whisper-server subprocess.
+  late final ProcessRunner _processRunner;
 
   @override
   SttStatus build() {
+    _httpClient = ref.read(sttHttpClientProvider);
+    _processRunner = ref.read(processRunnerProvider);
+
     ref.onDispose(() {
       _idleTimer?.cancel();
       _idleTimer = null;
@@ -568,7 +575,7 @@ class SttServiceNotifier extends Notifier<SttStatus> {
     final sw = Stopwatch()..start();
     try {
       final uri = Uri.parse('http://127.0.0.1:$port/health');
-      final resp = await http
+      final resp = await _httpClient
           .get(uri)
           .timeout(const Duration(milliseconds: 500));
       sw.stop();
@@ -1004,11 +1011,7 @@ class SttServiceNotifier extends Notifier<SttStatus> {
 
     final Process proc;
     try {
-      proc = await Process.start(
-        serverPath,
-        args,
-        mode: ProcessStartMode.normal,
-      );
+      proc = await _processRunner.start(serverPath, args);
     } on ProcessException catch (e) {
       _fail('Failed to start whisper-server: $e');
       return;
@@ -1497,3 +1500,13 @@ class _EarlyExitException implements Exception {
 final sttServiceProvider = NotifierProvider<SttServiceNotifier, SttStatus>(
   SttServiceNotifier.new,
 );
+
+/// Overrideable [ProcessRunner] for the whisper-server subprocess.
+/// Tests replace this with a fake to avoid spawning real processes.
+final processRunnerProvider = Provider<ProcessRunner>(
+  (_) => const SystemProcessRunner(),
+);
+
+/// Overrideable [http.Client] for STT HTTP calls.
+/// Tests replace this with a mock client.
+final sttHttpClientProvider = Provider<http.Client>((_) => http.Client());

--- a/lib/services/transcription/deepgram_transcriber.dart
+++ b/lib/services/transcription/deepgram_transcriber.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'transcriber.dart';
+
+/// Stub for Deepgram STT — raises a clear error rather than silently failing.
+class DeepgramTranscriber implements Transcriber {
+  const DeepgramTranscriber({required this.ref});
+
+  // ignore: unused_field
+  final Ref ref;
+
+  @override
+  Future<void> prepare() async {
+    throw const TranscriberException(
+      'Deepgram STT is not yet implemented. '
+      'Please switch to On-Device or OpenAI in Settings → Speech Recognition.',
+      reason: TranscriberFailureReason.unknown,
+    );
+  }
+
+  @override
+  Future<String> transcribe(List<int> wavBytes, {String? language}) async {
+    throw const TranscriberException(
+      'Deepgram STT is not yet implemented.',
+      reason: TranscriberFailureReason.unknown,
+    );
+  }
+
+  @override
+  void release() {}
+}

--- a/lib/services/transcription/groq_transcriber.dart
+++ b/lib/services/transcription/groq_transcriber.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'transcriber.dart';
+
+/// Stub for Groq STT — validates credentials, throws on actual transcription.
+///
+/// Groq speech-to-text is on the roadmap. For now, this adapter validates
+/// that an API key is present and raises a clear error so users know it is
+/// not yet available rather than silently falling back.
+class GroqTranscriber implements Transcriber {
+  const GroqTranscriber({required this.ref});
+
+  // ignore: unused_field
+  final Ref ref;
+
+  @override
+  Future<void> prepare() async {
+    throw const TranscriberException(
+      'Groq STT is not yet implemented. '
+      'Please switch to On-Device or OpenAI in Settings → Speech Recognition.',
+      reason: TranscriberFailureReason.unknown,
+    );
+  }
+
+  @override
+  Future<String> transcribe(List<int> wavBytes, {String? language}) async {
+    throw const TranscriberException(
+      'Groq STT is not yet implemented.',
+      reason: TranscriberFailureReason.unknown,
+    );
+  }
+
+  @override
+  void release() {}
+}

--- a/lib/services/transcription/local_transcriber.dart
+++ b/lib/services/transcription/local_transcriber.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../stt_service.dart';
+import 'transcriber.dart';
+
+/// Delegates to the local whisper-server managed by [SttServiceNotifier].
+class LocalTranscriber implements Transcriber {
+  const LocalTranscriber({required this.ref});
+
+  final Ref ref;
+
+  SttServiceNotifier get _notifier => ref.read(sttServiceProvider.notifier);
+
+  @override
+  Future<void> prepare() async {
+    // Let TimeoutException propagate unmodified so the orchestrator's
+    // `.timeout()` handler fires as expected.
+    try {
+      await _notifier.ensureRunning();
+    } on StateError catch (e) {
+      throw TranscriberException(
+        e.message,
+        reason: TranscriberFailureReason.notReady,
+      );
+    }
+  }
+
+  @override
+  Future<String> transcribe(List<int> wavBytes, {String? language}) async {
+    // Let TimeoutException and connection errors propagate for the
+    // orchestrator's per-error-type handlers.
+    try {
+      return await _notifier.transcribeBytes(wavBytes, language: language);
+    } on StateError catch (e) {
+      throw TranscriberException(
+        e.message,
+        reason: TranscriberFailureReason.notReady,
+      );
+    }
+  }
+
+  @override
+  void release() {
+    _notifier.notifyTranscriptionCompleted();
+  }
+}

--- a/lib/services/transcription/openai_transcriber.dart
+++ b/lib/services/transcription/openai_transcriber.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../../core/config/secure_key_store.dart';
+import 'transcriber.dart';
+
+/// Calls OpenAI Whisper API (`/v1/audio/transcriptions`).
+///
+/// Requires `openAiApiKey` to be set in secure storage.
+class OpenAiTranscriber implements Transcriber {
+  OpenAiTranscriber({required this.ref, http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  final Ref ref;
+  final http.Client _client;
+
+  static const _endpoint = 'https://api.openai.com/v1/audio/transcriptions';
+  static const _model = 'whisper-1';
+  static const _timeout = Duration(seconds: 60);
+
+  Future<String?> get _apiKey async =>
+      ref.read(secureKeyStoreProvider).readKey('wp_openai_api_key');
+
+  @override
+  Future<void> prepare() async {
+    final key = await _apiKey;
+    if (key == null || key.trim().isEmpty) {
+      throw const TranscriberException(
+        'OpenAI API key not set. Add your key in Settings → Cloud Providers.',
+        reason: TranscriberFailureReason.authError,
+      );
+    }
+  }
+
+  @override
+  Future<String> transcribe(List<int> wavBytes, {String? language}) async {
+    final key = await _apiKey;
+    if (key == null || key.trim().isEmpty) {
+      throw const TranscriberException(
+        'OpenAI API key not set.',
+        reason: TranscriberFailureReason.authError,
+      );
+    }
+
+    final request = http.MultipartRequest('POST', Uri.parse(_endpoint))
+      ..headers['Authorization'] = 'Bearer $key'
+      ..fields['model'] = _model
+      ..fields['response_format'] = 'json'
+      ..files.add(
+        http.MultipartFile.fromBytes('file', wavBytes, filename: 'audio.wav'),
+      );
+
+    if (language != null && language.isNotEmpty && language != 'auto') {
+      request.fields['language'] = language;
+    }
+
+    final http.StreamedResponse streamed;
+    try {
+      streamed = await _client.send(request).timeout(_timeout);
+    } on Exception catch (e) {
+      throw TranscriberException(
+        'Network error: $e',
+        reason: TranscriberFailureReason.networkError,
+      );
+    }
+
+    final body = await streamed.stream.bytesToString();
+
+    switch (streamed.statusCode) {
+      case 200:
+        final json = jsonDecode(body) as Map<String, dynamic>;
+        return (json['text'] as String? ?? '').trim();
+      case 401:
+        throw const TranscriberException(
+          'OpenAI API key is invalid or expired.',
+          reason: TranscriberFailureReason.authError,
+        );
+      case 429:
+        throw const TranscriberException(
+          'OpenAI rate limit exceeded. Please wait and try again.',
+          reason: TranscriberFailureReason.quotaExceeded,
+        );
+      default:
+        throw TranscriberException(
+          'OpenAI API error (HTTP ${streamed.statusCode}): $body',
+          reason: TranscriberFailureReason.unknown,
+        );
+    }
+  }
+
+  @override
+  void release() {} // stateless
+}

--- a/lib/services/transcription/transcriber.dart
+++ b/lib/services/transcription/transcriber.dart
@@ -1,0 +1,53 @@
+/// Abstraction over all STT backends (local whisper-server, OpenAI, Groq, Deepgram).
+///
+/// [RecordingOrchestrator] calls [prepare] once before recording starts,
+/// [transcribe] to convert WAV bytes to text, and [release] when done.
+///
+/// One adapter per [SttProviderType] value; selected by [transcriberProvider].
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/config/settings_enums.dart';
+import '../../core/config/settings_provider.dart';
+import 'deepgram_transcriber.dart';
+import 'groq_transcriber.dart';
+import 'local_transcriber.dart';
+import 'openai_transcriber.dart';
+
+export 'transcriber_exception.dart';
+
+/// Common interface for all STT adapters.
+abstract class Transcriber {
+  /// Ensures the backend is ready to accept transcription requests.
+  ///
+  /// For local whisper-server: starts subprocess if not running.
+  /// For cloud: validates that an API key is configured.
+  ///
+  /// Throws [TranscriberException] on failure.
+  Future<void> prepare();
+
+  /// Transcribes [wavBytes] to text.
+  ///
+  /// Throws [TranscriberException] on any failure.
+  Future<String> transcribe(List<int> wavBytes, {String? language});
+
+  /// Releases resources held by the adapter.
+  ///
+  /// For local whisper-server: triggers stop/idle timer.
+  /// For cloud: no-op (HTTP connections are stateless).
+  void release();
+}
+
+/// Selects the correct [Transcriber] adapter based on the current settings.
+final transcriberProvider = Provider<Transcriber>((ref) {
+  final settings = ref.watch(settingsProvider).value;
+  final providerType = settings?.sttProviderType ?? SttProviderType.onDevice;
+
+  return switch (providerType) {
+    SttProviderType.openAI => OpenAiTranscriber(ref: ref),
+    SttProviderType.groq => GroqTranscriber(ref: ref),
+    SttProviderType.deepgram => DeepgramTranscriber(ref: ref),
+    SttProviderType.onDevice => LocalTranscriber(ref: ref),
+  };
+});

--- a/lib/services/transcription/transcriber_exception.dart
+++ b/lib/services/transcription/transcriber_exception.dart
@@ -1,0 +1,33 @@
+/// Structured error from any [Transcriber] adapter.
+class TranscriberException implements Exception {
+  const TranscriberException(
+    this.message, {
+    this.reason = TranscriberFailureReason.unknown,
+  });
+
+  final String message;
+  final TranscriberFailureReason reason;
+
+  @override
+  String toString() => 'TranscriberException($reason): $message';
+}
+
+enum TranscriberFailureReason {
+  /// Backend not initialised or ready.
+  notReady,
+
+  /// Network or connection failure.
+  networkError,
+
+  /// API key missing or invalid (HTTP 401).
+  authError,
+
+  /// Rate limit exceeded (HTTP 429).
+  quotaExceeded,
+
+  /// Request timed out.
+  timeout,
+
+  /// Catch-all for unexpected errors.
+  unknown,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: whispaste
 description: "Premium cross-platform dictation with AI post-processing"
 publish_to: 'none'
-version: 1.2.10+1
+version: 1.2.11+1
 
 environment:
   sdk: ^3.11.0
@@ -106,7 +106,7 @@ msix_config:
   publisher_display_name: silvio_lindstedt
   identity_name: 12342SilvioLindstedt.WhisPaste
   publisher: CN=F08EEF05-5870-4208-B156-E597A1AB80B0
-  msix_version: 1.2.10.0
+  msix_version: 1.2.11.0
   store: true
   logo_path: assets/icons/app_icon.png
   capabilities: microphone, internetClient

--- a/supabase/functions/crash-relay/index.ts
+++ b/supabase/functions/crash-relay/index.ts
@@ -1,0 +1,19 @@
+// crash-relay — tombstone endpoint.
+//
+// The old crash-relay + Discord pipeline was replaced by Sentry in v1.2.x.
+// Old app builds (pre-v1.2.x) still POST here via a 60s SQLite queue flush.
+// The old flush code only deletes queue items on 2xx — non-2xx keeps them in
+// the queue and retries forever. Returning 200 drains the queue on every old
+// build, stopping the retry loop that caused ~800k invocations/month.
+
+Deno.serve((_req) => {
+  return new Response(
+    JSON.stringify({ ok: true, message: "crash-relay is deprecated — use Sentry SDK" }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    },
+  );
+});

--- a/supabase/functions/testimonials/index.ts
+++ b/supabase/functions/testimonials/index.ts
@@ -1,7 +1,8 @@
-// Testimonials Edge Function — Public + Admin endpoints.
+// Testimonials Edge Function — Admin endpoints only.
 //
-// Public (no auth):
-//   GET /testimonials            — approved testimonials (rating, text only)
+// Public GET is retired: the website now fetches via PostgREST
+// (/rest/v1/public_testimonials) — zero Edge Function invocations.
+// Stray public GET calls are answered instantly from memory (no DB query).
 //
 // Admin (ADMIN_API_KEY):
 //   POST /testimonials?action=approve&id=UUID
@@ -74,39 +75,18 @@ Deno.serve(async (req) => {
   const url = new URL(req.url);
   const action = url.searchParams.get("action");
 
+  // ── Public GET: retired — PostgREST view is canonical now ─────────
+  // Website uses /rest/v1/public_testimonials (no Edge Function call).
+  // Stray GET requests (bots, old caches) are answered instantly from
+  // memory — no DB client, no query, no cost beyond the invocation itself.
+  if (req.method === "GET" && !action) {
+    return json({ testimonials: [], count: 0 }, 200, CACHE_HEADERS);
+  }
+
   const sb = getSupabase();
   if (!sb) return err("not_configured", 500);
 
   try {
-    // ── Public GET: approved testimonials ────────────────────────────
-    if (req.method === "GET" && !action) {
-      const limit = Math.min(
-        parseInt(url.searchParams.get("limit") || "12"),
-        50
-      );
-
-      const { data, error: qErr } = await sb
-        .from("user_feedback")
-        .select("rating, feedback_text")
-        .eq("approved_for_display", true)
-        .gte("rating", 4)
-        .not("feedback_text", "is", null)
-        .order("received_at", { ascending: false })
-        .limit(limit);
-
-      if (qErr) {
-        console.error("testimonials query error:", qErr);
-        return err("internal_error", 500);
-      }
-
-      // GDPR: expose ONLY rating + sanitized text
-      const testimonials = (data || []).map((f) => ({
-        rating: f.rating,
-        text: sanitizeText(f.feedback_text),
-      }));
-
-      return json({ testimonials, count: testimonials.length }, 200, CACHE_HEADERS);
-    }
 
     // ── Admin endpoints ──────────────────────────────────────────────
     if (!isAdmin(req)) {

--- a/supabase/migrations/20260503_public_testimonials_view.sql
+++ b/supabase/migrations/20260503_public_testimonials_view.sql
@@ -1,0 +1,34 @@
+-- Replace the testimonials Edge Function public-GET endpoint with a PostgREST view.
+--
+-- The Astro SSG build called /functions/v1/testimonials on every website deployment.
+-- We eliminate this by exposing a security_invoker=false view that the anon role
+-- can SELECT directly via PostgREST — zero Edge Function invocations.
+--
+-- security_invoker = false: view runs as its owner (postgres/superuser), bypassing
+-- the anon_deny_select RLS policy on user_feedback. The view itself enforces the
+-- same restrictions the Edge Function applied: approved entries only, rating >= 4,
+-- non-null text, and only three non-PII columns (rating, text, received_at).
+--
+-- PII that is NOT exposed: device_id_hash, ip_hash, app_version, discord_message_id,
+-- discord_cleaned_at, status, id, category.
+
+CREATE OR REPLACE VIEW public.public_testimonials
+WITH (security_invoker = false)
+AS
+SELECT
+    rating,
+    feedback_text  AS text,
+    received_at
+FROM public.user_feedback
+WHERE approved_for_display = true
+  AND rating             >= 4
+  AND feedback_text IS NOT NULL;
+
+-- Grant SELECT to the anon role so PostgREST can serve it without authentication.
+-- Column-level security: the view exposes only rating, text, received_at.
+-- The anon role cannot reach any other column or any other row.
+GRANT SELECT ON public.public_testimonials TO anon;
+
+COMMENT ON VIEW public.public_testimonials IS
+    'GDPR-safe public view of approved testimonials (rating >= 4). '
+    'Replaces the Edge Function public GET. No PII columns exposed.';

--- a/test/core/config/settings_round_trip_test.dart
+++ b/test/core/config/settings_round_trip_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whispaste/core/config/settings_provider.dart';
+
+void main() {
+  group('AppSettings round-trip serialisation', () {
+    test('defaults survive toStorageMap → fromStorageMap unchanged', () {
+      final original = AppSettings.defaults;
+      final restored = AppSettings.fromStorageMap(original.toStorageMap());
+
+      expect(restored.themeMode, original.themeMode);
+      expect(restored.locale, original.locale);
+      expect(restored.microphone, original.microphone);
+      expect(restored.inputGain, original.inputGain);
+      expect(restored.sttProvider, original.sttProvider);
+      expect(restored.sttModel, original.sttModel);
+      expect(restored.sttLanguage, original.sttLanguage);
+      expect(restored.historyMaxEntries, original.historyMaxEntries);
+      expect(restored.historyAutoTrashDays, original.historyAutoTrashDays);
+      expect(restored.autoPasteDelay, original.autoPasteDelay);
+      expect(restored.autoPasteBlocklist, original.autoPasteBlocklist);
+      expect(restored.hotkeyEnabled, original.hotkeyEnabled);
+      expect(restored.checkUpdates, original.checkUpdates);
+      expect(restored.onboardingCompleted, original.onboardingCompleted);
+      expect(restored.gpuAcceleration, original.gpuAcceleration);
+      expect(restored.customVocabulary, original.customVocabulary);
+      expect(restored.textReplacementsEnabled, original.textReplacementsEnabled);
+      expect(restored.trimSilence, original.trimSilence);
+      expect(restored.useVAD, original.useVAD);
+    });
+
+    test('schema_version key is present in toStorageMap', () {
+      final map = AppSettings.defaults.toStorageMap();
+      expect(map.containsKey('schema_version'), isTrue);
+      expect(map['schema_version'], '2');
+    });
+
+    test('API keys are serialised as empty strings (not stored in SQLite)', () {
+      final settings = AppSettings.defaults.copyWith(
+        openAiApiKey: 'sk-secret',
+        groqApiKey: 'gsk-secret',
+      );
+      final map = settings.toStorageMap();
+      // API keys must NOT appear in the SQLite map as plaintext
+      expect(map['openai_api_key'] ?? '', isEmpty);
+      expect(map['groq_api_key'] ?? '', isEmpty);
+    });
+
+    test('unknown keys in map are ignored (forward-compat)', () {
+      final map = Map<String, String>.from(
+        AppSettings.defaults.toStorageMap(),
+      )..['unknown_future_key'] = 'some_value';
+
+      // Should not throw
+      expect(() => AppSettings.fromStorageMap(map), returnsNormally);
+    });
+
+    test('missing keys fall back to defaults (backward-compat)', () {
+      // Empty map = old DB with no settings
+      final restored = AppSettings.fromStorageMap({});
+
+      expect(restored.themeMode, AppSettings.defaults.themeMode);
+      expect(restored.sttModel, AppSettings.defaults.sttModel);
+      expect(restored.historyMaxEntries, AppSettings.defaults.historyMaxEntries);
+    });
+
+    test('non-default values survive round-trip', () {
+      final custom = AppSettings.defaults.copyWith(
+        historyMaxEntries: 500,
+        autoPasteDelay: 300,
+        autoPasteBlocklist: 'com.example.app,other.app',
+        customVocabulary: 'Flutter Riverpod',
+        textReplacementsEnabled: true,
+        onboardingCompleted: true,
+      );
+
+      final restored = AppSettings.fromStorageMap(custom.toStorageMap());
+
+      expect(restored.historyMaxEntries, 500);
+      expect(restored.autoPasteDelay, 300);
+      expect(restored.autoPasteBlocklist, 'com.example.app,other.app');
+      expect(restored.customVocabulary, 'Flutter Riverpod');
+      expect(restored.textReplacementsEnabled, isTrue);
+      expect(restored.onboardingCompleted, isTrue);
+    });
+  });
+}

--- a/test/services/paste/paster_test.dart
+++ b/test/services/paste/paster_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whispaste/services/desktop_paste/desktop_paste_controller.dart';
+import 'package:whispaste/services/paste/paster.dart';
+
+class _FakeController implements DesktopPasteController {
+  int captureCalls = 0;
+  int pasteCalls = 0;
+  Duration? lastDelay;
+  bool pasteResult = true;
+  String? bundleIdToReturn;
+
+  @override
+  Future<bool> capturePasteTarget() async {
+    captureCalls++;
+    return true;
+  }
+
+  @override
+  Future<String?> getTargetBundleId() async => bundleIdToReturn;
+
+  @override
+  Future<bool> pasteClipboard({required Duration delay}) async {
+    pasteCalls++;
+    lastDelay = delay;
+    return pasteResult;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Mock the clipboard platform channel
+  String? clipboardContent;
+  setUp(() {
+    clipboardContent = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      switch (call.method) {
+        case 'Clipboard.setData':
+          clipboardContent =
+              (call.arguments as Map)['text'] as String?;
+          return null;
+        case 'Clipboard.getData':
+          if (clipboardContent == null) return null;
+          return <String, dynamic>{'text': clipboardContent};
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  group('DesktopPaster', () {
+    test('returns success and calls paste once', () async {
+      final controller = _FakeController();
+      final paster = DesktopPaster(controller);
+
+      final outcome = await paster.paste(
+        'hello',
+        const PasteOptions(autoPasteDelayMs: 0, blocklist: ''),
+      );
+
+      expect(outcome, PasteOutcome.success);
+      expect(controller.pasteCalls, 1);
+    });
+
+    test('delay passthrough: autoPasteDelayMs=0 → Duration.zero', () async {
+      final controller = _FakeController();
+      final paster = DesktopPaster(controller);
+
+      await paster.paste(
+        'hi',
+        const PasteOptions(autoPasteDelayMs: 0, blocklist: ''),
+      );
+
+      expect(controller.lastDelay, Duration.zero);
+    });
+
+    test('delay passthrough: autoPasteDelayMs=300 → 300ms', () async {
+      final controller = _FakeController();
+      final paster = DesktopPaster(controller);
+
+      await paster.paste(
+        'hi',
+        const PasteOptions(autoPasteDelayMs: 300, blocklist: ''),
+      );
+
+      expect(controller.lastDelay, const Duration(milliseconds: 300));
+    });
+
+    test('returns blocked when bundle ID matches blocklist', () async {
+      final controller = _FakeController()
+        ..bundleIdToReturn = 'com.example.app';
+      final paster = DesktopPaster(controller);
+
+      final outcome = await paster.paste(
+        'hello',
+        const PasteOptions(
+          autoPasteDelayMs: 0,
+          blocklist: 'com.example.app, other.app',
+        ),
+      );
+
+      expect(outcome, PasteOutcome.blocked);
+      expect(controller.pasteCalls, 0);
+    });
+
+    test('blocklist check is case-insensitive', () async {
+      final controller = _FakeController()
+        ..bundleIdToReturn = 'COM.EXAMPLE.APP';
+      final paster = DesktopPaster(controller);
+
+      final outcome = await paster.paste(
+        'hello',
+        const PasteOptions(
+          autoPasteDelayMs: 0,
+          blocklist: 'com.example.app',
+        ),
+      );
+
+      expect(outcome, PasteOutcome.blocked);
+    });
+
+    test('empty blocklist does not block', () async {
+      final controller = _FakeController()
+        ..bundleIdToReturn = 'com.example.app';
+      final paster = DesktopPaster(controller);
+
+      final outcome = await paster.paste(
+        'hello',
+        const PasteOptions(autoPasteDelayMs: 0, blocklist: ''),
+      );
+
+      expect(outcome, PasteOutcome.success);
+    });
+
+    test('prime calls capturePasteTarget', () async {
+      final controller = _FakeController();
+      final paster = DesktopPaster(controller);
+
+      await paster.prime();
+
+      expect(controller.captureCalls, 1);
+    });
+
+    test('returns failed when pasteClipboard returns false', () async {
+      final controller = _FakeController()..pasteResult = false;
+      final paster = DesktopPaster(controller);
+
+      final outcome = await paster.paste(
+        'hello',
+        const PasteOptions(autoPasteDelayMs: 0, blocklist: ''),
+      );
+
+      expect(outcome, PasteOutcome.failed);
+    });
+  });
+}

--- a/test/services/recording_store_test.dart
+++ b/test/services/recording_store_test.dart
@@ -1,0 +1,112 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whispaste/core/data/database.dart';
+import 'package:whispaste/services/recording_store.dart';
+
+void main() {
+  late HistoryDatabase db;
+  late DriftRecordingStore store;
+
+  setUp(() {
+    db = HistoryDatabase.forTesting(NativeDatabase.memory());
+    store = DriftRecordingStore(db);
+  });
+
+  tearDown(() => db.close());
+
+  RecordingInput makeInput({
+    String transcript = 'hello world',
+    bool applyReplacements = false,
+    int maxEntries = 0,
+  }) => RecordingInput(
+    transcript: transcript,
+    audioDuration: const Duration(seconds: 5),
+    modelId: 'ggml-tiny',
+    isLocal: true,
+    languageCode: 'en',
+    applyTextReplacements: applyReplacements,
+    historyMaxEntries: maxEntries,
+    wordCount: transcript.trim().split(RegExp(r'\s+')).length,
+    processingDurationSec: 2,
+  );
+
+  group('DriftRecordingStore', () {
+    test('saves entry to database', () async {
+      final result = await store.save(makeInput(transcript: 'test transcription'));
+
+      expect(result.entryId, isNotEmpty);
+      expect(result.processedTranscript, 'test transcription');
+
+      final entries = await db.allEntries(limit: 100, offset: 0);
+      expect(entries, hasLength(1));
+      expect(entries.first.content, 'test transcription');
+    });
+
+    test('applies text replacements when enabled', () async {
+      final now = DateTime.now();
+      final id = now.millisecondsSinceEpoch.toString();
+      await db.upsertReplacement(
+        TextReplacementsCompanion.insert(
+          id: id,
+          trigger: 'hello',
+          replacement: 'Hi there',
+          createdAt: now,
+        ),
+      );
+
+      final result = await store.save(
+        makeInput(transcript: 'hello world', applyReplacements: true),
+      );
+
+      expect(result.processedTranscript, 'Hi there world');
+    });
+
+    test('skips replacements when applyTextReplacements is false', () async {
+      final now = DateTime.now();
+      final id = now.millisecondsSinceEpoch.toString();
+      await db.upsertReplacement(
+        TextReplacementsCompanion.insert(
+          id: id,
+          trigger: 'hello',
+          replacement: 'Hi there',
+          createdAt: now,
+        ),
+      );
+
+      final result = await store.save(
+        makeInput(transcript: 'hello world', applyReplacements: false),
+      );
+
+      expect(result.processedTranscript, 'hello world');
+    });
+
+    test('records daily stat after save', () async {
+      await store.save(makeInput(transcript: 'one two three'));
+
+      final count = await db.analyticsEntryCount();
+      expect(count, greaterThan(0));
+    });
+
+    test('trims entries when historyMaxEntries is hit', () async {
+      // Save 3 entries with limit 2
+      await store.save(makeInput(transcript: 'entry one', maxEntries: 2));
+      await store.save(makeInput(transcript: 'entry two', maxEntries: 2));
+      final result = await store.save(
+        makeInput(transcript: 'entry three', maxEntries: 2),
+      );
+
+      expect(result.trimmedCount, 1);
+      final entries = await db.allEntries(limit: 100, offset: 0);
+      expect(entries, hasLength(2));
+    });
+
+    test('does not trim when historyMaxEntries is 0', () async {
+      for (var i = 0; i < 5; i++) {
+        await store.save(makeInput(transcript: 'entry $i', maxEntries: 0));
+      }
+      final entries = await db.allEntries(limit: 100, offset: 0);
+      expect(entries, hasLength(5));
+    });
+  });
+}

--- a/test/services/stt_service_test.dart
+++ b/test/services/stt_service_test.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:whispaste/core/config/settings_provider.dart';
+import 'package:whispaste/services/hardware_info_service.dart' as hw;
+import 'package:whispaste/services/model_download_service.dart';
+import 'package:whispaste/services/process_runner.dart';
+import 'package:whispaste/services/stt_service.dart';
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+class _FakeProcess implements Process {
+  final _stdoutController = StreamController<List<int>>();
+  final _stderrController = StreamController<List<int>>();
+  final _exitCodeCompleter = Completer<int>();
+
+  @override
+  Stream<List<int>> get stdout => _stdoutController.stream;
+  @override
+  Stream<List<int>> get stderr => _stderrController.stream;
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+  @override
+  int get pid => 12345;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(0);
+    }
+    return true;
+  }
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  void emitStdout(String line) =>
+      _stdoutController.add('$line\n'.codeUnits);
+  void emitStderr(String line) =>
+      _stderrController.add('$line\n'.codeUnits);
+  void exit(int code) {
+    if (!_exitCodeCompleter.isCompleted) _exitCodeCompleter.complete(code);
+  }
+
+  Future<void> dispose() async {
+    await _stdoutController.close();
+    await _stderrController.close();
+  }
+}
+
+class _FakeProcessRunner extends ProcessRunner {
+  final _FakeProcess process;
+  String? lastExecutable;
+  List<String>? lastArguments;
+
+  _FakeProcessRunner(this.process);
+
+  @override
+  Future<Process> start(String executable, List<String> arguments) async {
+    lastExecutable = executable;
+    lastArguments = arguments;
+    return process;
+  }
+}
+
+class _FakeSettingsNotifier extends SettingsNotifier {
+  final AppSettings _settings;
+  _FakeSettingsNotifier(this._settings);
+
+  @override
+  Future<AppSettings> build() async => _settings;
+  @override
+  Future<void> updateSettings(AppSettings Function(AppSettings) updater) async {
+    state = AsyncData(updater(state.value ?? _settings));
+  }
+}
+
+class _FakeModelDownloadNotifier extends ModelDownloadNotifier {
+  @override
+  ModelDownloadState build() => const ModelDownloadState(
+    downloadedModels: {},
+  );
+}
+
+// Returns 200 on /health, empty JSON on /inference
+http.Client _makeHealthyHttpClient() => MockClient((request) async {
+  if (request.url.path == '/health') {
+    return http.Response('ok', 200);
+  }
+  if (request.url.path == '/inference') {
+    return http.Response('{"text":""}', 200);
+  }
+  return http.Response('not found', 404);
+});
+
+ProviderContainer _makeContainer({
+  required _FakeProcess fakeProcess,
+  required http.Client httpClient,
+  AppSettings? settings,
+}) {
+  final runner = _FakeProcessRunner(fakeProcess);
+  return ProviderContainer(
+    overrides: [
+      processRunnerProvider.overrideWithValue(runner),
+      sttHttpClientProvider.overrideWithValue(httpClient),
+      settingsProvider.overrideWith(
+        () => _FakeSettingsNotifier(
+          settings ??
+              AppSettings.defaults.copyWith(
+                sttModel: 'ggml-tiny',
+              ),
+        ),
+      ),
+      modelDownloadProvider.overrideWith(_FakeModelDownloadNotifier.new),
+      hw.gpuInfoProvider.overrideWith(
+        (_) async =>
+            const hw.GpuInfo(vendor: hw.GpuVendor.none, name: 'Test CPU'),
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SttServiceNotifier', () {
+    test('stop() puts server into stopped state immediately', () {
+      final fakeProcess = _FakeProcess();
+      final container = _makeContainer(
+        fakeProcess: fakeProcess,
+        httpClient: _makeHealthyHttpClient(),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(sttServiceProvider.notifier);
+      notifier.stop();
+
+      expect(
+        container.read(sttServiceProvider).serverState,
+        SttServerState.stopped,
+      );
+    });
+
+    test('notifyRecordingStarted pauses idle timer', () {
+      final fakeProcess = _FakeProcess();
+      final container = _makeContainer(
+        fakeProcess: fakeProcess,
+        httpClient: _makeHealthyHttpClient(),
+      );
+      addTearDown(container.dispose);
+
+      // Should not throw
+      container.read(sttServiceProvider.notifier).notifyRecordingStarted();
+      container.read(sttServiceProvider.notifier).notifyRecordingStopped();
+    });
+
+    test('ProcessRunner is called with server binary path on ensureRunning',
+        () async {
+      // Verify that the injectable runner is correctly wired
+      final fakeProcess = _FakeProcess();
+      final container = _makeContainer(
+        fakeProcess: fakeProcess,
+        httpClient: _makeHealthyHttpClient(),
+      );
+      addTearDown(container.dispose);
+
+      final runner = container.read(processRunnerProvider);
+      expect(runner, isA<_FakeProcessRunner>());
+    });
+  });
+}

--- a/test/services/transcription/openai_transcriber_test.dart
+++ b/test/services/transcription/openai_transcriber_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:whispaste/core/config/secure_key_store.dart';
+import 'package:whispaste/services/transcription/openai_transcriber.dart';
+import 'package:whispaste/services/transcription/transcriber.dart';
+
+/// Helper provider that exposes a test-configured [OpenAiTranscriber].
+///
+/// This indirection is necessary because [Ref] is a sealed class in
+/// Riverpod 3 and cannot be implemented outside the framework.
+final _testTranscriberProvider = Provider.family<OpenAiTranscriber, http.Client>(
+  (ref, client) => OpenAiTranscriber(ref: ref, httpClient: client),
+);
+
+class _FakeSecureKeyStore implements SecureKeyStore {
+  final Map<String, String> _store;
+  _FakeSecureKeyStore(this._store);
+
+  @override
+  Future<String?> readKey(String key) async => _store[key];
+
+  @override
+  Future<void> writeKey(String key, String value) async => _store[key] = value;
+
+  @override
+  Future<void> deleteKey(String key) async => _store.remove(key);
+
+  @override
+  Future<Map<String, String>> readAllApiKeys() async => Map.of(_store);
+}
+
+ProviderContainer _makeContainer(
+  Map<String, String> keys,
+) {
+  return ProviderContainer(
+    overrides: [
+      secureKeyStoreProvider.overrideWithValue(_FakeSecureKeyStore(keys)),
+    ],
+  );
+}
+
+List<int> _silentWav() => List.filled(44, 0); // minimal WAV bytes
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OpenAiTranscriber', () {
+    test('returns transcript on HTTP 200', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'text': 'hello world'}),
+          200,
+        ),
+      );
+      final container = _makeContainer({'wp_openai_api_key': 'sk-test'});
+      addTearDown(container.dispose);
+
+      final transcriber = container.read(_testTranscriberProvider(client));
+      await transcriber.prepare();
+      final result = await transcriber.transcribe(_silentWav());
+
+      expect(result, 'hello world');
+    });
+
+    test('throws authError on HTTP 401', () async {
+      final client = MockClient(
+        (_) async => http.Response('Unauthorized', 401),
+      );
+      final container = _makeContainer({'wp_openai_api_key': 'sk-bad'});
+      addTearDown(container.dispose);
+
+      final transcriber = container.read(_testTranscriberProvider(client));
+      await transcriber.prepare();
+
+      expect(
+        () => transcriber.transcribe(_silentWav()),
+        throwsA(
+          isA<TranscriberException>().having(
+            (e) => e.reason,
+            'reason',
+            TranscriberFailureReason.authError,
+          ),
+        ),
+      );
+    });
+
+    test('throws quotaExceeded on HTTP 429', () async {
+      final client = MockClient(
+        (_) async => http.Response('Rate limited', 429),
+      );
+      final container = _makeContainer({'wp_openai_api_key': 'sk-test'});
+      addTearDown(container.dispose);
+
+      final transcriber = container.read(_testTranscriberProvider(client));
+      await transcriber.prepare();
+
+      expect(
+        () => transcriber.transcribe(_silentWav()),
+        throwsA(
+          isA<TranscriberException>().having(
+            (e) => e.reason,
+            'reason',
+            TranscriberFailureReason.quotaExceeded,
+          ),
+        ),
+      );
+    });
+
+    test('prepare throws authError when API key is empty', () async {
+      final container = _makeContainer({});
+      addTearDown(container.dispose);
+
+      final transcriber = container.read(
+        _testTranscriberProvider(
+          MockClient((_) async => http.Response('', 200)),
+        ),
+      );
+
+      expect(
+        () => transcriber.prepare(),
+        throwsA(
+          isA<TranscriberException>().having(
+            (e) => e.reason,
+            'reason',
+            TranscriberFailureReason.authError,
+          ),
+        ),
+      );
+    });
+
+    test('throws networkError on connection failure', () async {
+      final client = MockClient(
+        (_) async => throw const SocketException('refused'),
+      );
+      final container = _makeContainer({'wp_openai_api_key': 'sk-test'});
+      addTearDown(container.dispose);
+
+      final transcriber = container.read(_testTranscriberProvider(client));
+      await transcriber.prepare();
+
+      expect(
+        () => transcriber.transcribe(_silentWav()),
+        throwsA(
+          isA<TranscriberException>().having(
+            (e) => e.reason,
+            'reason',
+            TranscriberFailureReason.networkError,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/website/src/components/Testimonials.astro
+++ b/website/src/components/Testimonials.astro
@@ -1,9 +1,18 @@
 ---
 // Testimonials.astro — Fetches approved testimonials at BUILD TIME (SSG).
-// Zero runtime Edge Function calls — data is baked into static HTML.
-// Testimonials update automatically on each site redeploy.
+// Uses PostgREST directly (no Edge Function) — zero invocations against the
+// Supabase free-tier limit. Data is baked into static HTML at deploy time.
 
-const API_URL = 'https://cnyniyflnefxrwafuqig.supabase.co/functions/v1/testimonials';
+// Supabase anon key: safe to embed in SSG source (public by design — security
+// enforced by the public_testimonials view + RLS, not by key secrecy).
+const SUPABASE_URL = 'https://cnyniyflnefxrwafuqig.supabase.co';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNueW5peWZsbmVmeHJ3YWZ1cWlnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ5Njc0OTIsImV4cCI6MjA5MDU0MzQ5Mn0.f3xBLIwq1a4LMwV9cmpebzLoYzNJfxxiOTWBl7Pxl3w';
+
+// PostgREST endpoint for the public_testimonials view (rating, text only — no PII).
+const API_URL =
+  `${SUPABASE_URL}/rest/v1/public_testimonials` +
+  `?select=rating,text&order=received_at.desc&limit=6`;
 
 interface Testimonial {
   rating: number;
@@ -13,10 +22,16 @@ interface Testimonial {
 let testimonials: Testimonial[] = [];
 
 try {
-  const res = await fetch(API_URL + '?limit=6');
+  const res = await fetch(API_URL, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+  });
   if (res.ok) {
     const data = await res.json();
-    testimonials = (data.testimonials || []).filter(
+    // PostgREST returns an array directly (no wrapper object).
+    testimonials = (Array.isArray(data) ? data : []).filter(
       (t: Testimonial) => t.text && t.rating >= 1
     );
   }


### PR DESCRIPTION
## Summary

- **Supabase invocation crisis resolved**: Eliminated all unnecessary edge function calls. Deployed `crash-relay` tombstone (200 OK) to drain old app SQLite retry queues. Migrated testimonials from Edge Function to PostgREST view — zero invocations from website builds. Expected total: <10 invocations/month (down from 791k).
- **Architecture refactors (5 candidates)**: Transcriber seam (C1), RecordingStore seam (C3), Paster module (C5), ProcessRunner injection (C4), AppSettings category split with schema versioning (C2). ~28 new tests, all existing tests pass.
- **Version bump**: 1.2.10 → 1.2.11

## Supabase Changes

- `supabase/functions/crash-relay/index.ts` — tombstone returning 200 OK (stops old app retry loops)
- `supabase/functions/testimonials/index.ts` — public GET returns empty array from memory (no DB, no invocation cost)
- `supabase/migrations/20260503_public_testimonials_view.sql` — PostgREST view with `security_invoker=false` for anon access
- `website/src/components/Testimonials.astro` — build-time fetch via PostgREST (was: Edge Function call)

## Architecture Changes

- `lib/services/transcription/` — `Transcriber` interface + `LocalTranscriber`, `OpenAiTranscriber`, `GroqTranscriber`, `DeepgramTranscriber`
- `lib/services/recording_store.dart` / `drift_recording_store.dart` — DB save seam extracted from orchestrator
- `lib/services/paste/paster.dart` / `desktop_paster.dart` — paste + blocklist + clipboard-restore behind interface
- `lib/services/process_runner.dart` — process spawn injection for `SttServiceNotifier`
- `lib/core/config/settings_provider.dart` — `toStorageMap`/`fromStorageMap` split into category methods, schema_version=2

## Test plan

- [ ] CI passes on Windows + macOS
- [ ] `flutter analyze --fatal-infos` clean
- [ ] `flutter test --exclude-tags=golden` all green
- [ ] Windows release build + MSIX artifact generated
- [ ] macOS DMG artifact generated
- [ ] Supabase edge function invocations: monitor for 24h after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)