### PR TITLE
fix(stt): fix broken CUDA12 entry in bundled manifest and manifest parsing when fallback to GitHub download 

### DIFF
--- a/assets/whisper-server-manifest.json
+++ b/assets/whisper-server-manifest.json
@@ -44,10 +44,9 @@
       "platform": "windows",
       "arch": "x64",
       "backend": "cuda12",
-      "url": "",
+      "url": "https://github.com/ggml-org/whisper.cpp/releases/download/v1.8.4/whisper-cublas-12.4.0-bin-x64.zip",
       "size_bytes": 457024596,
-      "source": "upstream",
-      "sha256": "https://github.com/ggml-org/whisper.cpp/releases/download/v1.8.4/whisper-cublas-12.4.0-bin-x64.zip"
+      "source": "upstream"
     }
   ]
 }

--- a/lib/services/whisper_server_manifest.dart
+++ b/lib/services/whisper_server_manifest.dart
@@ -291,20 +291,25 @@ class WhisperServerManifestLoader {
     required String label,
   }) async {
     try {
-      final response = await _dio.get<Map<String, dynamic>>(
+      // GitHub serves JSON manifests as text/plain (raw host) or
+      // application/octet-stream (release assets). Dio's ResponseType.json
+      // leaves the body as a String for those content-types and the
+      // `<Map<String, dynamic>>` cast then fails with DioExceptionType.unknown
+      // ("Netzwerkfehler: unknown"). Fetch as plain text and parse ourselves.
+      final response = await _dio.get<String>(
         url,
         options: Options(
-          responseType: ResponseType.json,
+          responseType: ResponseType.plain,
           sendTimeout: _remoteTimeout,
           receiveTimeout: _remoteTimeout,
         ),
       );
-      final data = response.data;
-      if (data == null) {
+      final body = response.data;
+      if (body == null || body.isEmpty) {
         _log.info('Manifest $label returned empty body ($url)');
         return null;
       }
-      final manifest = WhisperServerManifest.fromJson(data);
+      final manifest = WhisperServerManifest.fromJson(_parseJson(body));
       _log.info(
         'Loaded manifest from $label (tag=${manifest.whisperServerTag}, '
         'binaries=${manifest.binaries.length})',

--- a/lib/services/whisper_server_manifest.dart
+++ b/lib/services/whisper_server_manifest.dart
@@ -383,7 +383,8 @@ class WhisperBinarySelector {
       for (final binary in manifest.binaries) {
         if (binary.platform == platform &&
             binary.arch == arch &&
-            binary.backend == backend) {
+            binary.backend == backend &&
+            _isDownloadable(binary)) {
           return WhisperBinarySelection.match(binary);
         }
       }
@@ -398,6 +399,12 @@ class WhisperBinarySelector {
       'priorities $priority (manifest provides: $available, '
       'manifest tag=${manifest.whisperServerTag})',
     );
+  }
+
+  /// Whether [binary] has a non-empty http(s) URL the downloader can fetch.
+  static bool _isDownloadable(WhisperBinary binary) {
+    final url = binary.url.trim();
+    return url.startsWith('http://') || url.startsWith('https://');
   }
 
   /// Backend priority list — first match wins. Same precedence rules as

--- a/test/services/whisper_server_manifest_test.dart
+++ b/test/services/whisper_server_manifest_test.dart
@@ -216,6 +216,37 @@ void main() {
       expect(result.binary!.backend, 'cuda12');
     });
 
+    test('skips cuda12 with empty url and falls back to vulkan', () {
+      const selector = WhisperBinarySelector();
+      final brokenManifest = WhisperServerManifest.fromJson({
+        'schema_version': 1,
+        'whisper_server_tag': 'whisper-server-test',
+        'whisper_cpp_release': 'v1.8.4',
+        'generated_at': '2026-01-01T00:00:00Z',
+        'binaries': [
+          {
+            ..._bin('windows', 'x64', 'cuda12'),
+            'url': '',
+          },
+          _bin('windows', 'x64', 'vulkan'),
+          _bin('windows', 'x64', 'cpu'),
+        ],
+      });
+      final result = selector.select(
+        manifest: brokenManifest,
+        gpu: const hw.GpuInfo(
+          vendor: hw.GpuVendor.nvidia,
+          name: 'NV',
+          cudaAvailable: true,
+        ),
+        gpuMode: 'auto',
+        platformOverride: 'windows',
+        archOverride: 'x64',
+      );
+      expect(result.hasBinary, isTrue);
+      expect(result.binary!.backend, 'vulkan');
+    });
+
     test('NVIDIA without CUDA → vulkan beats cpu', () {
       const selector = WhisperBinarySelector();
       final result = selector.select(

--- a/test/services/whisper_server_manifest_test.dart
+++ b/test/services/whisper_server_manifest_test.dart
@@ -3,7 +3,6 @@
 library;
 
 import 'dart:async';
-import 'dart:convert' show jsonDecode;
 import 'dart:io' show Directory, File, Platform;
 import 'dart:typed_data' show Uint8List;
 
@@ -113,6 +112,34 @@ void main() {
       expect(manifest.whisperServerTag, 'whisper-server-raw');
       expect(rawHits, 1);
       expect(releaseHits, 0);
+    });
+
+    test('parses JSON served as text/plain (GitHub raw host content-type)', () async {
+      final dio = Dio();
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            handler.resolve(
+              Response(
+                requestOptions: options,
+                statusCode: 200,
+                headers: Headers.fromMap({
+                  'content-type': ['text/plain; charset=utf-8'],
+                }),
+                data: _rawManifest,
+              ),
+            );
+          },
+        ),
+      );
+
+      final loader = WhisperServerManifestLoader(
+        dio: dio,
+        bundleReader: () async => _bundledManifest,
+      );
+
+      final manifest = await loader.load();
+      expect(manifest.whisperServerTag, 'whisper-server-raw');
     });
 
     test('falls back to the release-asset URL when the raw URL fails, using '
@@ -749,10 +776,10 @@ Dio _routedDio({
           }
           if (result is String) {
             handler.resolve(
-              Response<Map<String, dynamic>>(
+              Response<String>(
                 requestOptions: options,
                 statusCode: 200,
-                data: jsonDecode(result) as Map<String, dynamic>,
+                data: result,
               ),
             );
             return;


### PR DESCRIPTION
## Summary

After updating WhisPaste to v1.2.40, I could no longer download the local whisper-server during onboarding — the download failed with a generic network error and the local model setup could not complete.

This PR fixes whisper-server onboarding/download failures caused by two manifest issues:

1. **Broken CUDA12 entry + undownloadable binaries** — The bundled manifest had an empty `url` for the Windows CUDA12 binary and a release URL mistakenly stored in `sha256`. `WhisperBinarySelector` matched that entry first on NVIDIA/CUDA systems and the downloader had nothing to fetch. Restore the upstream CUDA12 URL, remove the invalid `sha256`, and skip binaries without an `http(s)` URL so selection falls through to vulkan/cpu.
The manifest regression was introduced in [acc91e2e](https://github.com/whispaste/whispaste/commit/acc91e2e4443fbb01889e41eb7c84693f4696611), which emptied the Windows CUDA12 `url` and mistakenly stored the upstream release URL in `sha256`. 



2. **Remote manifest parsing** — GitHub serves `whisper-server-manifest.json` as `text/plain` (raw host) or `application/octet-stream` (release assets). `Dio` with `ResponseType.json` leaves the body as a `String` for those content-types; the subsequent `Map<String, dynamic>` cast then fails with `DioExceptionType.unknown` ("Netzwerkfehler: unknown"), so stages 1 and 2 of the manifest failover chain never succeed. Fetch as plain text and parse JSON explicitly.
The remote parsing issue has been latent since the manifest pipeline landed in [93476680](https://github.com/whispaste/whispaste/commit/934766807d7b6a252f7fb6e4d0364faaf5da4a87).


## Changes

- `lib/services/whisper_server_manifest.dart` — fetch remote manifests as `ResponseType.plain`; add `_isDownloadable()` guard in binary selection
- `assets/whisper-server-manifest.json` — restore CUDA12 download URL; remove malformed `sha256`
- `test/services/whisper_server_manifest_test.dart` — cover `text/plain` content-type parsing and CUDA12→vulkan fallback

## Test plan

- [ ] Fresh onboarding on Windows with NVIDIA GPU — whisper-server downloads successfully
- [ ] Verify manifest loads from raw.githubusercontent.com (stage 1) and release asset URL (stage 2)