### PR TITLE
🎨 Palette: Add semantic labels to title bar maximize button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing semantic label on stateful window controls
+**Learning:** Found that custom window controls (like maximize/restore toggles) sometimes miss semantic labels entirely, preventing screen reader users from understanding what the control does, especially when its icon and action change dynamically based on state.
+**Action:** Always wrap stateful icon-only window controls in `Semantics` and provide dynamic labels that reflect the current state (e.g., 'Restore window' vs 'Maximize window').

--- a/lib/widgets/title_bar.dart
+++ b/lib/widgets/title_bar.dart
@@ -52,6 +52,7 @@ class WpTitleBar extends StatelessWidget {
               isDark: isDark,
               semanticLabel: 'Minimize window',
             ),
+            // loam-ignore: a11y-interactive-semantics – semantics provided in _MaximizeButton.build
             _MaximizeButton(isDark: isDark),
             // loam-ignore: a11y-interactive-semantics – semantics provided in _WindowButton.build
             _WindowButton(
@@ -164,9 +165,12 @@ class _MaximizeButtonState extends State<_MaximizeButton> {
         ? WpColorsDark.textSecondary
         : WpColorsLight.textSecondary;
 
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _isHovered = true),
+    return Semantics(
+      label: _isMaximized ? 'Restore window' : 'Maximize window',
+      button: true,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: GestureDetector(
         onTap: () async {
@@ -198,7 +202,7 @@ class _MaximizeButtonState extends State<_MaximizeButton> {
           ),
         ),
       ),
-    );
+    ));
   }
 }
 


### PR DESCRIPTION
💡 **What:** Added a `Semantics` wrapper with a dynamic label to the stateful `_MaximizeButton` in `WpTitleBar`.
🎯 **Why:** The window control maximize button changes its icon based on state, but lacked an accessibility label, preventing screen reader users from understanding its function or current status.
📸 **Before/After:** Not a visual change.
♿ **Accessibility:** Screen readers will now announce "Maximize window" or "Restore window" depending on the window state instead of a generic untagged button.

*Note: Environment checks (`flutter test`/`flutter analyze`) were bypassed due to Dart version mismatches between the sandbox and `pubspec.yaml`.*

---
*PR created automatically by Jules for task [7833186128399383892](https://jules.google.com/task/7833186128399383892) started by @silvio-l*