### PR TITLE
⚡ Bolt: [performance improvement] Wrap WpWaveform in RepaintBoundary

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-02 - Continuous Waveform Repaints
+**Learning:** High-frequency animations (like the waveform in WpWaveform) inside standard widget trees trigger continuous repaints that bubble up.
+**Action:** Always wrap continuous AnimatedBuilder components (especially those painting complex paths or CustomPaint) in a RepaintBoundary to isolate the redraws.

--- a/lib/widgets/waveform.dart
+++ b/lib/widgets/waveform.dart
@@ -119,29 +119,33 @@ class _WpWaveformState extends State<WpWaveform>
         widget.inactiveColor ??
         (isDark ? WpColorsDark.surfaceVariant : WpColorsLight.surfaceVariant);
 
-    return AnimatedBuilder(
-      animation: _controller,
-      builder: (context, _) {
-        return CustomPaint(
-          size: Size(
-            widget.barCount * (widget.barWidth + widget.barSpacing) -
-                widget.barSpacing,
-            widget.height,
-          ),
-          painter: _WaveformPainter(
-            audioLevel: widget.isActive ? widget.audioLevel : 0.0,
-            barCount: widget.barCount,
-            barWidth: widget.barWidth,
-            barSpacing: widget.barSpacing,
-            activeColor: activeColor,
-            idleColor: idleColor,
-            phaseA: _phaseA,
-            phaseB: _phaseB,
-            phaseC: _phaseC,
-            tick: _controller.value,
-          ),
-        );
-      },
+    // ⚡ Bolt: Added RepaintBoundary to isolate continuous waveform repaints
+    // from invalidating the rest of the widget tree.
+    return RepaintBoundary(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          return CustomPaint(
+            size: Size(
+              widget.barCount * (widget.barWidth + widget.barSpacing) -
+                  widget.barSpacing,
+              widget.height,
+            ),
+            painter: _WaveformPainter(
+              audioLevel: widget.isActive ? widget.audioLevel : 0.0,
+              barCount: widget.barCount,
+              barWidth: widget.barWidth,
+              barSpacing: widget.barSpacing,
+              activeColor: activeColor,
+              idleColor: idleColor,
+              phaseA: _phaseA,
+              phaseB: _phaseB,
+              phaseC: _phaseC,
+              tick: _controller.value,
+            ),
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
💡 **What**: Wrapped the `AnimatedBuilder` inside `WpWaveform` in a `RepaintBoundary`. Added a comment to explain the optimization.
🎯 **Why**: `WpWaveform` runs continuously during recording (at 60fps) using a `CustomPaint`. Without a `RepaintBoundary`, these constant invalidations can bubble up the widget tree, causing unnecessary redraws in parent widgets. By wrapping it, the waveform gets its own composite layer.
📊 **Impact**: Reduces unnecessary re-renders in the parent UI tree when the waveform is animating. This frees up the main thread from redundant paint operations, making the recording overlay snappier.
🔬 **Measurement**: Inspect Flutter DevTools Timeline while recording. You should observe fewer widgets repainting on each frame.

(Note: Tests and lint could not be fully run due to SDK version mismatches in the environment).

---
*PR created automatically by Jules for task [4222621456234487371](https://jules.google.com/task/4222621456234487371) started by @silvio-l*