### PR TITLE
🎨 Palette: [UX improvement] Add tooltips to note buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-03 - Missing Tooltips on Icon-Only Buttons
+**Learning:** Found that custom icon-only interactive elements using `InkWell` or `GestureDetector` in this codebase were missing `Tooltip` wrappers, hindering accessibility and usability for screen reader and mouse users.
+**Action:** Always verify that icon-only buttons (`InkWell`, `GestureDetector`, etc.) have `Tooltip` or `Semantics` wrappers, and apply them using localized strings if absent.

--- a/lib/features/history/widgets/history_notes_section.dart
+++ b/lib/features/history/widgets/history_notes_section.dart
@@ -492,27 +492,33 @@ class _NoteItemState extends State<_NoteItem> {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        InkWell(
-                          onTap: widget.onStartEdit,
-                          borderRadius: WpRadius.borderSm,
-                          child: Padding(
-                            padding: const EdgeInsets.all(WpSpacing.xs),
-                            child: Icon(
-                              LucideIcons.pencil,
-                              size: WpIconSize.sm,
-                              color: widget.textMuted,
+                        Tooltip(
+                          message: L10n.of(context).actionEdit,
+                          child: InkWell(
+                            onTap: widget.onStartEdit,
+                            borderRadius: WpRadius.borderSm,
+                            child: Padding(
+                              padding: const EdgeInsets.all(WpSpacing.xs),
+                              child: Icon(
+                                LucideIcons.pencil,
+                                size: WpIconSize.sm,
+                                color: widget.textMuted,
+                              ),
                             ),
                           ),
                         ),
-                        InkWell(
-                          onTap: widget.onDelete,
-                          borderRadius: WpRadius.borderSm,
-                          child: Padding(
-                            padding: const EdgeInsets.all(WpSpacing.xs),
-                            child: Icon(
-                              LucideIcons.x,
-                              size: WpIconSize.sm,
-                              color: widget.textMuted,
+                        Tooltip(
+                          message: L10n.of(context).actionDelete,
+                          child: InkWell(
+                            onTap: widget.onDelete,
+                            borderRadius: WpRadius.borderSm,
+                            child: Padding(
+                              padding: const EdgeInsets.all(WpSpacing.xs),
+                              child: Icon(
+                                LucideIcons.x,
+                                size: WpIconSize.sm,
+                                color: widget.textMuted,
+                              ),
                             ),
                           ),
                         ),


### PR DESCRIPTION
💡 What: Added Tooltip widgets around the icon-only InkWell buttons (Edit and Delete) in the HistoryNotesSection.
🎯 Why: Icon-only buttons without tooltips or semantic labels are ambiguous to users and inaccessible to screen readers.
♿ Accessibility: The Tooltip widget provides both visual hover feedback and an accessible label for screen readers.

---
*PR created automatically by Jules for task [15227770036877228966](https://jules.google.com/task/15227770036877228966) started by @silvio-l*