### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Sentry breadcrumbs leaking secrets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Sentry Breadcrumbs Leak Secrets
+**Vulnerability:** Sentry breadcrumbs from log statements could contain sensitive information (like API keys) and leak them to crash reports.
+**Learning:** `AppLogger` is the source of breadcrumbs, and `event.breadcrumbs` was not being scrubbed in Sentry `beforeSend`, even though `event.message` and `event.exceptions` were.
+**Prevention:** In `CrashReporter.beforeSend`, always apply the `containsSensitiveData` checker not just to the primary message/exception, but also to `event.breadcrumbs`. Return `null` to drop the crash report entirely if any part of it is tainted.

--- a/lib/core/logging/crash_reporter.dart
+++ b/lib/core/logging/crash_reporter.dart
@@ -269,6 +269,14 @@ class CrashReporter {
     if (message != null && containsSensitiveData(message.formatted)) {
       return null;
     }
+    final breadcrumbs = event.breadcrumbs;
+    if (breadcrumbs != null) {
+      for (final b in breadcrumbs) {
+        if (b.message != null && containsSensitiveData(b.message!)) {
+          return null;
+        }
+      }
+    }
 
     // Filter out user-facing toast messages (not real errors)
     final messageStr =


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Sentry crash reports could leak API keys or other secrets if they were inadvertently logged and included as context in `event.breadcrumbs`.
🎯 **Impact:** If an API key were logged, it would end up in the crash report breadcrumbs and sent to Sentry's backend, exposing user secrets.
🔧 **Fix:** Modified `CrashReporter.beforeSend` to iterate over all `event.breadcrumbs`. If any breadcrumb contains sensitive data (via `containsSensitiveData`), the entire crash event is dropped (`return null`).
✅ **Verification:** Verified logically; `flutter test` could not be run fully due to sandbox SDK limitations, but package tests pass.

---
*PR created automatically by Jules for task [11320172232787840877](https://jules.google.com/task/11320172232787840877) started by @silvio-l*