### PR TITLE
⚡ Bolt: [performance improvement] Memoize avatar color computation on hover

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-03 - Memoize missing expensive calculation in history rows
+**Learning:** `HistoryEntryRow` and `HistoryEntryCard` correctly memoized word count and avatar icon to prevent recalculation on every hover `setState`, but they forgot to memoize `historyAvatarColor` which does an expensive string `codeUnits.fold` iteration! Also, `historyAvatarColor` accepted an unused `isDark` parameter.
+**Action:** When auditing `setState` triggered by frequent interactions like hover, ensure *all* derived state that depends only on static widget properties is memoized, not just the complex JSON parsing ones. String iteration (folding over `codeUnits`) adds up when triggered multiple times a second during fast scrolling/hovering.

--- a/lib/features/history/widgets/history_card_view.dart
+++ b/lib/features/history/widgets/history_card_view.dart
@@ -156,6 +156,7 @@ class _HistoryEntryCardState extends State<HistoryEntryCard> {
   // setState — see the identical fix in history_list_tile.dart for why.
   late int _wordCount = _computeWordCount(widget.entry);
   late IconData _avatarIcon = historyAvatarIcon(widget.entry);
+  late Color _avatarCol = historyAvatarColor(widget.entry);
 
   static int _computeWordCount(HistoryEntry entry) {
     return computeWordCountFast(entry.content);
@@ -167,6 +168,7 @@ class _HistoryEntryCardState extends State<HistoryEntryCard> {
     if (oldWidget.entry != widget.entry) {
       _wordCount = _computeWordCount(widget.entry);
       _avatarIcon = historyAvatarIcon(widget.entry);
+      _avatarCol = historyAvatarColor(widget.entry);
     }
   }
 
@@ -211,7 +213,6 @@ class _HistoryEntryCardState extends State<HistoryEntryCard> {
   Widget build(BuildContext context) {
     final isDark = widget.isDark;
     final l10n = L10n.of(context);
-    final avatarCol = historyAvatarColor(widget.entry, isDark);
     final colors = _resolveColors(isDark);
     final textPrimary = colors.textPrimary;
     final textSecondary = colors.textSecondary;
@@ -264,7 +265,7 @@ class _HistoryEntryCardState extends State<HistoryEntryCard> {
                 Row(
                   children: [
                     HistoryEntryAvatar(
-                      color: avatarCol,
+                      color: _avatarCol,
                       icon: _avatarIcon,
                       isPinned: widget.entry.pinned,
                       isDark: isDark,

--- a/lib/features/history/widgets/history_detail_panel.dart
+++ b/lib/features/history/widgets/history_detail_panel.dart
@@ -649,7 +649,7 @@ class _DetailPanelHeader extends StatelessWidget {
         : WpColorsLight.textSecondary;
     final textMuted = isDark ? WpColorsDark.textMuted : WpColorsLight.textMuted;
     final accent = isDark ? WpColorsDark.accent : WpColorsLight.accent;
-    final avatarCol = historyAvatarColor(entry, isDark);
+    final avatarCol = historyAvatarColor(entry);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(

--- a/lib/features/history/widgets/history_helpers.dart
+++ b/lib/features/history/widgets/history_helpers.dart
@@ -38,7 +38,7 @@ String formatHistoryDuration(double durationSec) {
 }
 
 /// Derives a warm avatar color from the entry's first tag or title.
-Color historyAvatarColor(HistoryEntry entry, bool isDark) {
+Color historyAvatarColor(HistoryEntry entry) {
   const palette = WpSharedColors.avatarPalette;
   // Hash from title for consistent color per entry
   final hash = entry.title.isNotEmpty

--- a/lib/features/history/widgets/history_list_tile.dart
+++ b/lib/features/history/widgets/history_list_tile.dart
@@ -63,6 +63,7 @@ class _HistoryEntryRowState extends State<HistoryEntryRow> {
   late int _wordCount = _computeWordCount(widget.entry);
   late List<String> _entryTags = _computeEntryTags(widget.entry);
   late IconData _avatarIcon = historyAvatarIcon(widget.entry);
+  late Color _avatarCol = historyAvatarColor(widget.entry);
 
   static int _computeWordCount(HistoryEntry entry) {
     return computeWordCountFast(entry.content);
@@ -85,6 +86,7 @@ class _HistoryEntryRowState extends State<HistoryEntryRow> {
       _wordCount = _computeWordCount(widget.entry);
       _entryTags = _computeEntryTags(widget.entry);
       _avatarIcon = historyAvatarIcon(widget.entry);
+      _avatarCol = historyAvatarColor(widget.entry);
     }
   }
 
@@ -105,7 +107,6 @@ class _HistoryEntryRowState extends State<HistoryEntryRow> {
   @override
   Widget build(BuildContext context) {
     final isDark = widget.isDark;
-    final avatarCol = historyAvatarColor(widget.entry, isDark);
 
     // Row background
     final Color bg;
@@ -235,7 +236,7 @@ class _HistoryEntryRowState extends State<HistoryEntryRow> {
                   ),
                 // Avatar — colored circle with content-type icon
                 HistoryEntryAvatar(
-                  color: avatarCol,
+                      color: _avatarCol,
                   icon: _avatarIcon,
                   isPinned: widget.entry.pinned,
                   isDark: isDark,


### PR DESCRIPTION
💡 **What**:
Memoized the `historyAvatarColor` calculation in `HistoryEntryRow` and `HistoryEntryCard` to avoid recalculating it on every render, such as during hover states. Also removed the unused `isDark` argument from `historyAvatarColor`.

🎯 **Why**:
The `historyAvatarColor` function computes a hash based on the entry's title or ID using a string iteration (`codeUnits.fold`). Calling this repeatedly inside the `build` method of list and card items introduces unnecessary overhead when `setState` is triggered for minor interactive changes (like hover/focus), leading to wasted CPU cycles when scrolling or moving the mouse over the history list.

📊 **Impact**:
Reduces expensive string iterations per frame when hovering over history entries, slightly lowering CPU utilization and avoiding micro-stutters during heavy list interaction.

🔬 **Measurement**:
Can be verified by monitoring the Flutter performance overlay while quickly moving the mouse up and down a long list of history entries. The build time per frame will drop.

---
*PR created automatically by Jules for task [11343410054851433801](https://jules.google.com/task/11343410054851433801) started by @silvio-l*