### PR TITLE
🎨 Palette: [a11y improvement] Add semantic labels to history note icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-04 - Missing ARIA Labels in Flutter IconButtons
+**Learning:** IconButton widgets in Flutter only provide a Semantics hint via their `tooltip` property, not a true Semantics name/label. Similarly, InkWell wrapped in Tooltip also does not announce a reliable label to screen readers.
+**Action:** Always wrap `IconButton` or interactive `Tooltip` widgets with `Semantics(label: ..., button: true)` to ensure screen readers properly announce the action to users.

--- a/lib/features/history/widgets/history_notes_section.dart
+++ b/lib/features/history/widgets/history_notes_section.dart
@@ -185,17 +185,21 @@ class HistoryNotesSectionState extends ConsumerState<HistoryNotesSection> {
                   ),
                   const SizedBox(width: WpSpacing.xxs),
                   if (!_isAdding)
-                    Tooltip(
-                      message: l10n.historyAddNote,
-                      child: InkWell(
-                        onTap: () => setState(() => _isAdding = true),
-                        borderRadius: WpRadius.borderSm,
-                        child: Padding(
-                          padding: const EdgeInsets.all(WpSpacing.xs),
-                          child: Icon(
-                            LucideIcons.plus,
-                            size: WpIconSize.md,
-                            color: accent,
+                    Semantics(
+                      label: l10n.historyAddNote,
+                      button: true,
+                      child: Tooltip(
+                        message: l10n.historyAddNote,
+                        child: InkWell(
+                          onTap: () => setState(() => _isAdding = true),
+                          borderRadius: WpRadius.borderSm,
+                          child: Padding(
+                            padding: const EdgeInsets.all(WpSpacing.xs),
+                            child: Icon(
+                              LucideIcons.plus,
+                              size: WpIconSize.md,
+                              color: accent,
+                            ),
                           ),
                         ),
                       ),
@@ -251,28 +255,36 @@ class HistoryNotesSectionState extends ConsumerState<HistoryNotesSection> {
                         ),
                       ),
                     ),
-                    IconButton(
-                      icon: Icon(
-                        LucideIcons.check,
-                        size: WpIconSize.md,
-                        color: accent,
+                    Semantics(
+                      label: l10n.actionSave,
+                      button: true,
+                      child: IconButton(
+                        icon: Icon(
+                          LucideIcons.check,
+                          size: WpIconSize.md,
+                          color: accent,
+                        ),
+                        onPressed: _addNote,
+                        padding: const EdgeInsets.all(WpSpacing.xs),
+                        tooltip: l10n.actionSave,
                       ),
-                      onPressed: _addNote,
-                      padding: const EdgeInsets.all(WpSpacing.xs),
-                      tooltip: l10n.actionSave,
                     ),
-                    IconButton(
-                      icon: Icon(
-                        LucideIcons.x,
-                        size: WpIconSize.md,
-                        color: textMuted,
+                    Semantics(
+                      label: l10n.actionCancel,
+                      button: true,
+                      child: IconButton(
+                        icon: Icon(
+                          LucideIcons.x,
+                          size: WpIconSize.md,
+                          color: textMuted,
+                        ),
+                        onPressed: () {
+                          _controller.clear();
+                          setState(() => _isAdding = false);
+                        },
+                        padding: const EdgeInsets.all(WpSpacing.xs),
+                        tooltip: l10n.actionCancel,
                       ),
-                      onPressed: () {
-                        _controller.clear();
-                        setState(() => _isAdding = false);
-                      },
-                      padding: const EdgeInsets.all(WpSpacing.xs),
-                      tooltip: l10n.actionCancel,
                     ),
                     const SizedBox(width: WpSpacing.xxs),
                   ],
@@ -435,25 +447,33 @@ class _NoteItemState extends State<_NoteItem> {
                       ),
                     ),
                   ),
-                  IconButton(
-                    icon: Icon(
-                      LucideIcons.check,
-                      size: WpIconSize.md,
-                      color: widget.accent,
+                  Semantics(
+                    label: L10n.of(context).actionSave,
+                    button: true,
+                    child: IconButton(
+                      icon: Icon(
+                        LucideIcons.check,
+                        size: WpIconSize.md,
+                        color: widget.accent,
+                      ),
+                      onPressed: widget.onSave,
+                      padding: const EdgeInsets.all(WpSpacing.xxs),
+                      tooltip: L10n.of(context).actionSave,
                     ),
-                    onPressed: widget.onSave,
-                    padding: const EdgeInsets.all(WpSpacing.xxs),
-                    tooltip: L10n.of(context).actionSave,
                   ),
-                  IconButton(
-                    icon: Icon(
-                      LucideIcons.x,
-                      size: WpIconSize.md,
-                      color: widget.textMuted,
+                  Semantics(
+                    label: L10n.of(context).actionCancel,
+                    button: true,
+                    child: IconButton(
+                      icon: Icon(
+                        LucideIcons.x,
+                        size: WpIconSize.md,
+                        color: widget.textMuted,
+                      ),
+                      onPressed: widget.onCancel,
+                      padding: const EdgeInsets.all(WpSpacing.xxs),
+                      tooltip: L10n.of(context).actionCancel,
                     ),
-                    onPressed: widget.onCancel,
-                    padding: const EdgeInsets.all(WpSpacing.xxs),
-                    tooltip: L10n.of(context).actionCancel,
                   ),
                 ],
               )
@@ -492,32 +512,40 @@ class _NoteItemState extends State<_NoteItem> {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Tooltip(
-                          message: L10n.of(context).actionEdit,
-                          child: InkWell(
-                            onTap: widget.onStartEdit,
-                            borderRadius: WpRadius.borderSm,
-                            child: Padding(
-                              padding: const EdgeInsets.all(WpSpacing.xs),
-                              child: Icon(
-                                LucideIcons.pencil,
-                                size: WpIconSize.sm,
-                                color: widget.textMuted,
+                        Semantics(
+                          label: L10n.of(context).actionEdit,
+                          button: true,
+                          child: Tooltip(
+                            message: L10n.of(context).actionEdit,
+                            child: InkWell(
+                              onTap: widget.onStartEdit,
+                              borderRadius: WpRadius.borderSm,
+                              child: Padding(
+                                padding: const EdgeInsets.all(WpSpacing.xs),
+                                child: Icon(
+                                  LucideIcons.pencil,
+                                  size: WpIconSize.sm,
+                                  color: widget.textMuted,
+                                ),
                               ),
                             ),
                           ),
                         ),
-                        Tooltip(
-                          message: L10n.of(context).actionDelete,
-                          child: InkWell(
-                            onTap: widget.onDelete,
-                            borderRadius: WpRadius.borderSm,
-                            child: Padding(
-                              padding: const EdgeInsets.all(WpSpacing.xs),
-                              child: Icon(
-                                LucideIcons.x,
-                                size: WpIconSize.sm,
-                                color: widget.textMuted,
+                        Semantics(
+                          label: L10n.of(context).actionDelete,
+                          button: true,
+                          child: Tooltip(
+                            message: L10n.of(context).actionDelete,
+                            child: InkWell(
+                              onTap: widget.onDelete,
+                              borderRadius: WpRadius.borderSm,
+                              child: Padding(
+                                padding: const EdgeInsets.all(WpSpacing.xs),
+                                child: Icon(
+                                  LucideIcons.x,
+                                  size: WpIconSize.sm,
+                                  color: widget.textMuted,
+                                ),
                               ),
                             ),
                           ),


### PR DESCRIPTION
💡 **What**: Added `Semantics` wrappers with explicit `label` and `button: true` to icon-only buttons (`IconButton`, `Tooltip` + `InkWell`) in `lib/features/history/widgets/history_notes_section.dart`. Also added a journal entry for this accessibility pattern.
🎯 **Why**: Flutter's `IconButton` `tooltip` property only yields a Semantics *hint*, not a true Semantics *name* for screen readers, meaning these buttons were largely inaccessible or announced poorly. 
📸 **Before/After**: N/A (Non-visual semantics change)
♿ **Accessibility**: Significant improvement for screen reader users traversing the note items in the history list; they will now correctly hear "Add note, button", "Save, button", "Cancel, button", "Edit, button", "Delete, button".

---
*PR created automatically by Jules for task [16723160407903599099](https://jules.google.com/task/16723160407903599099) started by @silvio-l*