### PR TITLE
🎨 Palette: Improve accessibility of API key visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - IconButton Semantics
+
+**Learning:** In Flutter, using `IconButton(tooltip: ...)` alone only provides a Semantics hint to screen readers, not a true label. This means the button might be announced incorrectly or just as "button".
+**Action:** Always wrap `IconButton` and interactive `Tooltip` widgets in `Semantics(label: ..., button: true)` to ensure proper accessibility labels for screen readers.

--- a/lib/features/settings/settings_widgets.dart
+++ b/lib/features/settings/settings_widgets.dart
@@ -409,18 +409,22 @@ Widget settingsApiKeyField({
         ),
         Positioned(
           right: 0,
-          child: IconButton(
-            icon: Icon(
-              obscure ? LucideIcons.eye : LucideIcons.eyeOff,
-              size: WpIconSize.sm,
-              color: isDark ? WpColorsDark.textMuted : WpColorsLight.textMuted,
-            ),
-            onPressed: onToggle,
-            tooltip: L10n.of(context).settingsToggleApiKeyVisibility,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(
-              minWidth: WpLayout.minTouchTarget,
-              minHeight: WpLayout.minTouchTarget,
+          child: Semantics(
+            label: L10n.of(context).settingsToggleApiKeyVisibility,
+            button: true,
+            child: IconButton(
+              icon: Icon(
+                obscure ? LucideIcons.eye : LucideIcons.eyeOff,
+                size: WpIconSize.sm,
+                color: isDark ? WpColorsDark.textMuted : WpColorsLight.textMuted,
+              ),
+              onPressed: onToggle,
+              tooltip: L10n.of(context).settingsToggleApiKeyVisibility,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(
+                minWidth: WpLayout.minTouchTarget,
+                minHeight: WpLayout.minTouchTarget,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
💡 **What:** Added a explicit `Semantics` wrapper around the API key visibility toggle button in the settings.
🎯 **Why:** In Flutter, `IconButton(tooltip: ...)` only provides a Semantics hint. Wrapping it ensures it is announced correctly as a button with a proper label to screen readers.
📸 **Before/After:** N/A (Visuals remain exactly the same)
♿ **Accessibility:** Screen readers will now explicitly read "Toggle API Key Visibility" as the label for the button instead of relying solely on a hint.

---
*PR created automatically by Jules for task [16395535811914602186](https://jules.google.com/task/16395535811914602186) started by @silvio-l*