### PR TITLE
⚡ Bolt: Pre-compile regex for history search to avoid string allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Case-Insensitive String Filtering Allocation
+**Learning:** Dart's String.toLowerCase() allocates a new string. Doing this multiple times per item in an Iterable.where() tight loop causes massive GC pressure, especially when users type quickly in a search bar over a large dataset.
+**Action:** Always prefer precompiled RegExp(pattern, caseSensitive: false) for case-insensitive filtering in list processing, initializing it once outside the loop to avoid O(N) allocations.

--- a/lib/features/history/data/providers.dart
+++ b/lib/features/history/data/providers.dart
@@ -224,26 +224,40 @@ List<HistoryEntry> _applyParsedSearch(
   List<HistoryEntry> entries,
   ParsedSearchQuery parsed,
 ) {
+  // PERF (Bolt): Pre-compile regexes outside the loop to avoid allocating
+  // multiple new lowercased strings per entry during search filtering.
+  final freeTextRegex = parsed.freeText.isNotEmpty
+      ? RegExp(RegExp.escape(parsed.freeText), caseSensitive: false)
+      : null;
+
+  final langRegex = parsed.langCode != null && parsed.langCode!.isNotEmpty
+      ? RegExp('^${RegExp.escape(parsed.langCode!)}', caseSensitive: false)
+      : null;
+
+  final tagRegexes = parsed.tagNames.isNotEmpty
+      ? parsed.tagNames
+          .map((t) => RegExp(RegExp.escape(t), caseSensitive: false))
+          .toList()
+      : null;
+
   return entries.where((e) {
     // Free-text match
-    if (parsed.freeText.isNotEmpty) {
-      final lower = parsed.freeText.toLowerCase();
-      if (!e.title.toLowerCase().contains(lower) &&
-          !e.content.toLowerCase().contains(lower)) {
+    if (freeTextRegex != null) {
+      if (!freeTextRegex.hasMatch(e.title) &&
+          !freeTextRegex.hasMatch(e.content)) {
         return false;
       }
     }
     // Language filter
-    if (parsed.langCode != null && parsed.langCode!.isNotEmpty) {
-      if (!e.language.toLowerCase().startsWith(parsed.langCode!)) {
+    if (langRegex != null) {
+      if (!langRegex.hasMatch(e.language)) {
         return false;
       }
     }
     // Tag filter — check the JSON tags field on the entry
-    if (parsed.tagNames.isNotEmpty) {
-      final entryTags = e.tags.toLowerCase();
-      for (final tag in parsed.tagNames) {
-        if (!entryTags.contains(tag)) return false;
+    if (tagRegexes != null) {
+      for (final tagRegex in tagRegexes) {
+        if (!tagRegex.hasMatch(e.tags)) return false;
       }
     }
     return true;


### PR DESCRIPTION
💡 What: Replaced inline `toLowerCase()` calls in `_applyParsedSearch` with pre-compiled `RegExp` objects evaluated outside the filtering loop.
🎯 Why: `String.toLowerCase()` creates a new string allocation. Calling it multiple times per item within an `Iterable.where` tight loop during search filtering causes significant memory allocation and garbage collection pressure, leading to UI jank on large history datasets.
📊 Impact: Eliminates O(N) string allocations during search filtering, significantly reducing memory overhead and improving UI responsiveness.
🔬 Measurement: Verify by typing quickly in the history search bar with a large dataset (e.g. >1000 items) and observe reduced memory usage and smoother frame rates compared to before.

---
*PR created automatically by Jules for task [5983039939690267051](https://jules.google.com/task/5983039939690267051) started by @silvio-l*