### PR TITLE
🎨 Palette: [UX improvement] Add Semantics to Theme Toggle IconButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-06 - Missing Semantics in IconButton
+**Learning:** In Flutter, `IconButton` and interactive `Tooltip` widgets only provide a Semantics hint, not a true label for screen readers. This leaves icon-only buttons inaccessible.
+**Action:** For accessibility, always wrap them in `Semantics(label: ..., button: true)`.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1066,17 +1066,21 @@ class _ThemeToggle extends ConsumerWidget {
     final mutedColor = isDark
         ? WpColorsDark.textMuted
         : WpColorsLight.textMuted;
-    return IconButton(
-      icon: Icon(
-        isDark ? LucideIcons.moon : LucideIcons.sun,
-        color: mutedColor,
-        size: 16,
+    return Semantics(
+      label: isDark ? l10n.tooltipSwitchToLight : l10n.tooltipSwitchToDark,
+      button: true,
+      child: IconButton(
+        icon: Icon(
+          isDark ? LucideIcons.moon : LucideIcons.sun,
+          color: mutedColor,
+          size: 16,
+        ),
+        tooltip: isDark ? l10n.tooltipSwitchToLight : l10n.tooltipSwitchToDark,
+        onPressed: () => ref.read(settingsProvider.notifier).toggleDarkLight(),
+        splashRadius: 16,
+        constraints: const BoxConstraints(minWidth: 36, minHeight: 32),
+        padding: EdgeInsets.zero,
       ),
-      tooltip: isDark ? l10n.tooltipSwitchToLight : l10n.tooltipSwitchToDark,
-      onPressed: () => ref.read(settingsProvider.notifier).toggleDarkLight(),
-      splashRadius: 16,
-      constraints: const BoxConstraints(minWidth: 36, minHeight: 32),
-      padding: EdgeInsets.zero,
     );
   }
 }


### PR DESCRIPTION
💡 What: Wrapped the `_ThemeToggle` `IconButton` in `lib/app.dart` with a `Semantics` widget.
🎯 Why: In Flutter, `IconButton` and interactive `Tooltip` widgets only provide a Semantics hint, leaving icon-only buttons inaccessible to screen readers without a true label.
📸 Before/After: Visuals remain unchanged; structural enhancement for screen readers.
♿ Accessibility: Provides a clear, screen-reader-accessible label and marks the widget as a button.

---
*PR created automatically by Jules for task [1911999082171133142](https://jules.google.com/task/1911999082171133142) started by @silvio-l*