### PR TITLE
🎨 Palette: [UX improvement] Enhance screen reader accessibility for interactive text fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-10-18 - Accessibility on interactive text widgets
+**Learning:** Interactive text widgets handled via `GestureDetector` (e.g. click-to-edit text blocks) rely on tooltips for sighted users but do not inherently announce themselves as interactive to screen readers.
+**Action:** Always wrap interactive `GestureDetector` regions with `Semantics(button: true, label: ...)` to ensure screen reader users are aware the text area can be interacted with.

--- a/lib/features/history/widgets/history_detail_panel.dart
+++ b/lib/features/history/widgets/history_detail_panel.dart
@@ -715,29 +715,36 @@ class _DetailPanelHeader extends StatelessWidget {
                     Row(
                       children: [
                         Expanded(
-                          child: Tooltip(
-                            message: isTrashView ? '' : l10n.historyEditTitle,
-                            waitDuration: const Duration(milliseconds: 600),
-                            child: GestureDetector(
-                              onDoubleTap: isTrashView
-                                  ? null
-                                  : onStartTitleEdit,
-                              child: MouseRegion(
-                                cursor: isTrashView
-                                    ? SystemMouseCursors.basic
-                                    : SystemMouseCursors.click,
-                                child: HighlightedText(
-                                  text: entry.title.isNotEmpty
-                                      ? entry.title
-                                      : l10n.historyUntitled,
-                                  style: TextStyle(
-                                    fontSize: WpTypography.heading,
-                                    fontWeight: FontWeight.w700,
-                                    color: textPrimary,
+                          child: Semantics(
+                            button: !isTrashView,
+                            onTapHint: isTrashView
+                                ? null
+                                : l10n.historyEditTitle,
+                            onTap: isTrashView ? null : onStartTitleEdit,
+                            child: Tooltip(
+                              message: isTrashView ? '' : l10n.historyEditTitle,
+                              waitDuration: const Duration(milliseconds: 600),
+                              child: GestureDetector(
+                                onDoubleTap: isTrashView
+                                    ? null
+                                    : onStartTitleEdit,
+                                child: MouseRegion(
+                                  cursor: isTrashView
+                                      ? SystemMouseCursors.basic
+                                      : SystemMouseCursors.click,
+                                  child: HighlightedText(
+                                    text: entry.title.isNotEmpty
+                                        ? entry.title
+                                        : l10n.historyUntitled,
+                                    style: TextStyle(
+                                      fontSize: WpTypography.heading,
+                                      fontWeight: FontWeight.w700,
+                                      color: textPrimary,
+                                    ),
+                                    isDark: isDark,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
-                                  isDark: isDark,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
                                 ),
                               ),
                             ),
@@ -1071,26 +1078,29 @@ class _DetailTranscriptZone extends StatelessWidget {
                           onSubmitted: (_) => onSaveTranscript(),
                         ),
                       )
-                    : Tooltip(
-                        message: l10n.historyEditTranscript,
-                        waitDuration: const Duration(milliseconds: 600),
-                        child: GestureDetector(
-                          onTap: isTrashView ? null : onToggleEdit,
-                          behavior: HitTestBehavior.translucent,
-                          child: MouseRegion(
-                            cursor: isTrashView
-                                ? SystemMouseCursors.basic
-                                : SystemMouseCursors.click,
-                            child: HighlightedText(
-                              text: entry.content.isEmpty
-                                  ? '\u200B'
-                                  : entry.content,
-                              style: TextStyle(
-                                fontSize: WpTypography.heading,
-                                color: textPrimary,
-                                height: 1.65,
+                    : Semantics(
+                        button: !isTrashView,
+                        child: Tooltip(
+                          message: l10n.historyEditTranscript,
+                          waitDuration: const Duration(milliseconds: 600),
+                          child: GestureDetector(
+                            onTap: isTrashView ? null : onToggleEdit,
+                            behavior: HitTestBehavior.translucent,
+                            child: MouseRegion(
+                              cursor: isTrashView
+                                  ? SystemMouseCursors.basic
+                                  : SystemMouseCursors.click,
+                              child: HighlightedText(
+                                text: entry.content.isEmpty
+                                    ? '\u200B'
+                                    : entry.content,
+                                style: TextStyle(
+                                  fontSize: WpTypography.heading,
+                                  color: textPrimary,
+                                  height: 1.65,
+                                ),
+                                isDark: isDark,
                               ),
-                              isDark: isDark,
                             ),
                           ),
                         ),


### PR DESCRIPTION
💡 **What:** Added explicit `Semantics(button: true)` wrappers around the interactive text blocks for the history detail panel's title and transcript zones. Also mapped the title's `onDoubleTap` to the semantic `onTap` so screen readers can easily trigger the edit action.

🎯 **Why:** Sighted users see tooltips when hovering over these text areas indicating they are editable, but screen readers only read the content as plain text, meaning visually impaired users might not discover they can interact with the text to edit it.

📸 **Before/After:**
*(Visuals remain unchanged, but accessibility tree structure has improved)*

♿ **Accessibility:** Screen readers will now announce these text areas as buttons (when active) and can trigger the edit mode via standard screen reader tap gestures. Added entry to Palette journal.

---
*PR created automatically by Jules for task [8129655584727891064](https://jules.google.com/task/8129655584727891064) started by @silvio-l*