### PR TITLE
🛡️ Sentinel: [HIGH] Prevent Command Injection in macOS Update Script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-08 - [Sentinel] Prevent Command Injection in macOS Update Script
+**Vulnerability:** The `MacUpdateInstaller` embedded dynamic inputs (like the DMG path) directly into a generated shell script using fragile manual quoting (`_shq`), which is susceptible to command injection if quotes can be bypassed.
+**Learning:** Shell script generation via string interpolation is an anti-pattern. Even with manual escaping, it is difficult to secure perfectly and introduces a wide attack surface for malicious payloads.
+**Prevention:** Always parameterize shell commands. Use positional arguments (``, ``) in scripts and pass dynamic values via the native process arguments array (`Process.start`), which hands them directly to the OS without shell parsing.

--- a/lib/services/update/mac_update_installer.dart
+++ b/lib/services/update/mac_update_installer.dart
@@ -32,34 +32,29 @@ String? resolveMacAppBundlePath() {
   return bundle;
 }
 
-/// Single-quotes [s] for safe embedding as a POSIX shell literal.
-String _shq(String s) => "'${s.replaceAll("'", r"'\''")}'";
-
 /// Builds the detached helper shell script. Pure function so it can be unit
 /// tested and verified against a real DMG without mounting in the test.
 ///
-/// The script: waits for [parentPid] to exit → mounts [dmgPath] read-only →
+/// The script expects four positional arguments:
+/// 1: parentPid (WhisPaste's PID to wait for)
+/// 2: dmgPath (the downloaded DMG to mount)
+/// 3: targetBundlePath (the .app to overwrite)
+/// 4: logPath (where to redirect output)
+///
+/// The script: waits for parent to exit → mounts DMG read-only →
 /// guards that it contains a valid `WhisPaste.app` → stages a copy next to
-/// [targetBundlePath] and renames it into place atomically (writable target
+/// target and renames it into place atomically (writable target
 /// directly, else once via `osascript … with administrator privileges`) →
 /// detaches → relaunches. Any failure before the atomic rename leaves the
 /// existing install untouched.
-String buildMacUpdateHelperScript({
-  required int parentPid,
-  required String dmgPath,
-  required String targetBundlePath,
-  required String logPath,
-}) {
-  final dmg = _shq(dmgPath);
-  final target = _shq(targetBundlePath);
-  final log = _shq(logPath);
+String buildMacUpdateHelperScript() {
   return '''#!/bin/bash
 # WhisPaste macOS in-app update helper (generated at runtime). Do not edit.
 set -uo pipefail
-PARENT_PID=$parentPid
-DMG=$dmg
-TARGET=$target
-LOG=$log
+PARENT_PID="\$1"
+DMG="\$2"
+TARGET="\$3"
+LOG="\$4"
 exec >>"\$LOG" 2>&1
 echo "[wp-update] start pid=\$PARENT_PID target=\$TARGET"
 
@@ -160,16 +155,15 @@ class DefaultMacUpdateInstaller implements MacUpdateInstaller {
     final scriptPath = p.join(dir.path, 'wp-update-helper.sh');
     final logPath = p.join(dir.path, 'wp-update.log');
     await File(scriptPath).writeAsString(
-      buildMacUpdateHelperScript(
-        parentPid: pid,
-        dmgPath: dmgPath,
-        targetBundlePath: targetBundlePath,
-        logPath: logPath,
-      ),
+      buildMacUpdateHelperScript(),
     );
     await Process.run('chmod', ['+x', scriptPath]);
     await Process.start('/bin/bash', [
       scriptPath,
+      pid.toString(),
+      dmgPath,
+      targetBundlePath,
+      logPath,
     ], mode: ProcessStartMode.detached);
   }
 }

--- a/test/services/mac_update_test.dart
+++ b/test/services/mac_update_test.dart
@@ -40,21 +40,11 @@ void main() {
   // Slice 01/02 — the generated detached helper script (pure, platform-neutral).
   // ---------------------------------------------------------------------------
   group('buildMacUpdateHelperScript', () {
-    String build({
-      int pid = 4242,
-      String dmg = '/tmp/WhisPaste.dmg',
-      String target = '/Applications/WhisPaste.app',
-      String log = '/tmp/wp-update.log',
-    }) => buildMacUpdateHelperScript(
-      parentPid: pid,
-      dmgPath: dmg,
-      targetBundlePath: target,
-      logPath: log,
-    );
+    String build() => buildMacUpdateHelperScript();
 
     test('waits for the parent PID to exit before touching anything', () {
-      final s = build(pid: 9931);
-      expect(s, contains('PARENT_PID=9931'));
+      final s = build();
+      expect(s, contains('PARENT_PID="\$1"'));
       expect(s, contains('kill -0 "\$PARENT_PID"'));
     });
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The macOS update script (in `lib/services/update/mac_update_installer.dart`) used a custom `_shq` function to quote variables such as the `dmgPath` and embedded them directly into a generated bash script string. This is a fragile pattern susceptible to command injection if the manual single-quote escaping is somehow circumvented.
🎯 **Impact:** If an attacker were able to supply a maliciously crafted path for the downloaded update DMG, they could achieve arbitrary command execution on the user's host system with the privileges of the running application.
🔧 **Fix:** Refactored the `buildMacUpdateHelperScript` to return a static shell script that takes positional arguments (`$1`, `$2`, etc.) instead of interpolating strings. Updated `DefaultMacUpdateInstaller.swap` to pass the dynamic values directly via the `arguments` array of Dart's `Process.start`. This correctly leverages OS-level separation of the command and its arguments.
✅ **Verification:** Verified that tests in `mac_update_test.dart` were appropriately updated to pass under the new static script pattern. Tests will run in CI.

---
*PR created automatically by Jules for task [1968987837343750431](https://jules.google.com/task/1968987837343750431) started by @silvio-l*