### PR TITLE
🌱 Sprout: Add dedicated clear search string for settings

### DIFF
--- a/.Jules/sprout.md
+++ b/.Jules/sprout.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing string definition
+**Learning:** The settings search field uses `l10n.historyClearSearch` to clear the search field, causing a minor inconsistency as it borrows from the history feature's string set rather than having its own dedicated `settingsClearSearch`.
+**Action:** Create a separate `settingsClearSearch` string in the localization files and use it in the `SettingsSearchField` widget to improve string scoping and separation of concerns.

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -1036,6 +1036,7 @@
   "parakeetModelCancel": "Abbrechen",
 
   "settingsSearchHint": "Einstellungen durchsuchen…",
+  "settingsClearSearch": "Suche zurücksetzen",
   "settingsSearchNoResults": "Keine Treffer",
   "settingsSearchNoResultsHint": "Versuche einen anderen Suchbegriff.",
   "settingsSearchFieldLabel": "Einstellungen durchsuchen",

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -1170,6 +1170,7 @@
   "parakeetModelCancel": "Cancel",
 
   "settingsSearchHint": "Search settings…",
+  "settingsClearSearch": "Clear search",
   "settingsSearchNoResults": "No Results",
   "settingsSearchNoResultsHint": "Try a different search term.",
   "settingsSearchFieldLabel": "Search settings",

--- a/lib/core/l10n/app_he.arb
+++ b/lib/core/l10n/app_he.arb
@@ -1048,6 +1048,7 @@
   "settingsGpuAccelerationDisabled": "CPU בלבד",
 
   "settingsSearchHint": "חיפוש הגדרות…",
+  "settingsClearSearch": "נקה חיפוש",
   "settingsSearchNoResults": "אין תוצאות",
   "settingsSearchNoResultsHint": "נסה מונח חיפוש אחר.",
   "settingsSearchFieldLabel": "חיפוש הגדרות",

--- a/lib/core/l10n/generated/app_localizations.dart
+++ b/lib/core/l10n/generated/app_localizations.dart
@@ -5541,6 +5541,12 @@ abstract class L10n {
   /// **'Search settings…'**
   String get settingsSearchHint;
 
+  /// No description provided for @settingsClearSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear search'**
+  String get settingsClearSearch;
+
   /// No description provided for @settingsSearchNoResults.
   ///
   /// In en, this message translates to:

--- a/lib/core/l10n/generated/app_localizations_de.dart
+++ b/lib/core/l10n/generated/app_localizations_de.dart
@@ -3131,6 +3131,9 @@ class L10nDe extends L10n {
   String get settingsSearchHint => 'Einstellungen durchsuchen…';
 
   @override
+  String get settingsClearSearch => 'Suche zurücksetzen';
+
+  @override
   String get settingsSearchNoResults => 'Keine Treffer';
 
   @override

--- a/lib/core/l10n/generated/app_localizations_en.dart
+++ b/lib/core/l10n/generated/app_localizations_en.dart
@@ -3103,6 +3103,9 @@ class L10nEn extends L10n {
   String get settingsSearchHint => 'Search settings…';
 
   @override
+  String get settingsClearSearch => 'Clear search';
+
+  @override
   String get settingsSearchNoResults => 'No Results';
 
   @override

--- a/lib/core/l10n/generated/app_localizations_he.dart
+++ b/lib/core/l10n/generated/app_localizations_he.dart
@@ -3057,6 +3057,9 @@ class L10nHe extends L10n {
   String get settingsSearchHint => 'חיפוש הגדרות…';
 
   @override
+  String get settingsClearSearch => 'נקה חיפוש';
+
+  @override
   String get settingsSearchNoResults => 'אין תוצאות';
 
   @override

--- a/lib/features/settings/widgets/settings_search_field.dart
+++ b/lib/features/settings/widgets/settings_search_field.dart
@@ -242,7 +242,7 @@ class _SettingsSearchFieldState extends ConsumerState<SettingsSearchField> {
                         size: WpIconSize.sm,
                         color: textMuted,
                       ),
-                      tooltip: l10n.historyClearSearch,
+                      tooltip: l10n.settingsClearSearch,
                       onPressed: _clearSearch,
                     )
                   : null,


### PR DESCRIPTION
**🌱 What**
Added a dedicated `settingsClearSearch` localization string and updated the settings search field to use it.

**💡 Why**
The settings search field previously reused the `historyClearSearch` string to clear its input. While they both say "Clear search", creating a dedicated string for the settings module improves separation of concerns and prevents future decoupling issues if the translations need to diverge. 

**🧩 Why this is low-risk**
This is a purely text/localization update. The implementation only touches `.arb` translation files, generates new Dart localization bindings, and updates a single string reference in the `SettingsSearchField` widget. There is virtually zero regression or security risk.

**🔧 Implementation**
Added `settingsClearSearch` to `app_en.arb`, `app_de.arb`, and `app_he.arb`. Updated the `SettingsSearchField` to use `l10n.settingsClearSearch`.

**✅ Verification**
- Checked `SettingsSearchField` for proper reference updating.
- Regenerated localization files using `flutter gen-l10n`. 
- *(Note: `flutter analyze` and `flutter test` were bypassed due to sandbox Dart SDK limitations).*

---
*PR created automatically by Jules for task [13698586637470605473](https://jules.google.com/task/13698586637470605473) started by @silvio-l*