### PR TITLE
⚡ Bolt: Optimize search filtering with pre-compiled RegExp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Case-insensitive filtering in Dart tight loops
 **Learning:** Using `String.toLowerCase()` inside a tight `where` loop in Dart allocates a new String for every item evaluated. In lists of strings like search results or tag lists, this creates massive GC pressure.
 **Action:** Use a precompiled `RegExp` with `caseSensitive: false` before the loop, and use `searchRegex.hasMatch(item)` inside the loop instead.
+## 2026-08-10 - Pre-compile case-insensitive RegExps for tight loops
+**Learning:** Calling `.toLowerCase()` repeatedly inside `where()` clauses in Dart search logic can cause performance hits by allocating a new String for every iteration.
+**Action:** Instead of `target.toLowerCase().contains(query)`, pre-compile `RegExp(RegExp.escape(query), caseSensitive: false)` before the loop and use `.hasMatch(target)` inside the loop.

--- a/lib/features/replacements/replacements_page.dart
+++ b/lib/features/replacements/replacements_page.dart
@@ -195,8 +195,8 @@ class _ReplacementsPageState extends ConsumerState<ReplacementsPage> {
       ),
       asyncAll: ref.watch(replacementsProvider),
       searchMatches: (r, q) =>
-          r.triggers.any((t) => t.toLowerCase().contains(q)) ||
-          r.replacement.toLowerCase().contains(q),
+          r.triggers.any((t) => q.hasMatch(t)) ||
+          q.hasMatch(r.replacement),
       searchHint: l10n.replacementsSearch,
       addLabel: l10n.replacementsAdd,
       onAdd: () => _showAddEditDialog(),

--- a/lib/features/settings/search/settings_search_provider.dart
+++ b/lib/features/settings/search/settings_search_provider.dart
@@ -76,11 +76,11 @@ List<SettingsSearchEntry> matchSettingsEntries(
 ) {
   final trimmed = query.trim();
   if (trimmed.isEmpty) return const [];
-  final needle = _fold(trimmed.toLowerCase());
+  final regex = RegExp(RegExp.escape(_fold(trimmed)), caseSensitive: false);
   return table.where((e) {
-    if (_fold(e.title(locale).toLowerCase()).contains(needle)) return true;
-    if (_fold(e.subtitle(locale).toLowerCase()).contains(needle)) return true;
-    return e.keywords.any((kw) => _fold(kw.toLowerCase()).contains(needle));
+    if (regex.hasMatch(_fold(e.title(locale)))) return true;
+    if (regex.hasMatch(_fold(e.subtitle(locale)))) return true;
+    return e.keywords.any((kw) => regex.hasMatch(_fold(kw)));
   }).toList();
 }
 

--- a/lib/features/snippets/snippets_page.dart
+++ b/lib/features/snippets/snippets_page.dart
@@ -167,7 +167,7 @@ class _SnippetsPageState extends ConsumerState<SnippetsPage> {
           : null,
       asyncAll: ref.watch(snippetsProvider),
       searchMatches: (s, q) =>
-          s.title.toLowerCase().contains(q) || s.body.toLowerCase().contains(q),
+          q.hasMatch(s.title) || q.hasMatch(s.body),
       searchHint: l10n.snippetsSearch,
       addLabel: l10n.snippetsAdd,
       onAdd: () => _showAddEditDialog(),

--- a/lib/widgets/searchable_list_page.dart
+++ b/lib/widgets/searchable_list_page.dart
@@ -45,8 +45,8 @@ class WpSearchableListPage<T> extends StatefulWidget {
   final AsyncValue<List<T>> asyncAll;
 
   /// Whether [item] matches the search query. Called only for non-empty
-  /// queries; `query` is already lowercased.
-  final bool Function(T item, String query) searchMatches;
+  /// queries; `query` is a precompiled case-insensitive regex.
+  final bool Function(T item, RegExp query) searchMatches;
 
   /// Hint text of the toolbar search field.
   final String searchHint;
@@ -116,7 +116,7 @@ class _WpSearchableListPageState<T> extends State<WpSearchableListPage<T>> {
 
   List<T> _filtered(List<T> all) {
     if (_searchQuery.isEmpty) return all;
-    final q = _searchQuery.toLowerCase();
+    final q = RegExp(RegExp.escape(_searchQuery), caseSensitive: false);
     return all.where((item) => widget.searchMatches(item, q)).toList();
   }
 


### PR DESCRIPTION
💡 What: Replaced repeated `.toLowerCase().contains()` calls in tight `.where()` search loops with a pre-compiled, case-insensitive `RegExp` using `.hasMatch()`.

🎯 Why: Calling `.toLowerCase()` inside a loop allocates a new string for every evaluated item on every keystroke. This causes immense Garbage Collection (GC) pressure for long lists (e.g., search results in snippets, replacements, and settings), which can lead to UI jank and slower search filtering.

📊 Impact: Reduces memory allocation by preventing `O(N)` new strings from being created per search keystroke. Filtering operations should be noticeably faster with less GC overhead.

🔬 Measurement: Test search behavior on the Snippets, Replacements, and Settings pages. The search matching will behave identically without performance hits.

---
*PR created automatically by Jules for task [14994697982108154570](https://jules.google.com/task/14994697982108154570) started by @silvio-l*