### PR TITLE
🎨 Palette: Add tooltip and semantics to tag input submit icon

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,5 @@
 ## 2025-10-18 - Accessibility on interactive text widgets
 **Learning:** Interactive text widgets handled via `GestureDetector` (e.g. click-to-edit text blocks) rely on tooltips for sighted users but do not inherently announce themselves as interactive to screen readers.
-**Action:** Always wrap interactive `GestureDetector` regions with `Semantics(button: true, label: ...)` to ensure screen reader users are aware the text area can be interacted with.
+**Action:** Always wrap interactive `GestureDetector` regions with `Semantics(button: true, label: ...)` to ensure screen reader users are aware the text area can be interacted with.## 2026-08-10 - Accessible Interactive Text Elements in Flutter
+**Learning:** Interactive text/icon elements built with `GestureDetector` do not inherently announce as interactive to screen readers, lack desktop hover cues (pointer cursor), and miss tooltips.
+**Action:** When adding interactivity via `GestureDetector`, explicitly wrap it in `Semantics(button: true, label: ...)`, `Tooltip`, and `MouseRegion(cursor: SystemMouseCursors.click)` to ensure an accessible, native-feeling experience across all input modalities (mouse, touch, keyboard/screen reader).

--- a/lib/widgets/tag_input.dart
+++ b/lib/widgets/tag_input.dart
@@ -364,14 +364,24 @@ class WpTagInputState extends State<WpTagInput> {
             vertical: WpSpacing.xxs + 2,
           ),
           suffixIcon: hasText
-              ? GestureDetector(
-                  onTap: () => _submit(_controller.text),
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: WpSpacing.xxs),
-                    child: Icon(
-                      LucideIcons.cornerDownLeft,
-                      size: 14,
-                      color: textMuted,
+              ? Semantics(
+                  button: true,
+                  label: 'Add tag',
+                  child: Tooltip(
+                    message: 'Add tag',
+                    child: MouseRegion(
+                      cursor: SystemMouseCursors.click,
+                      child: GestureDetector(
+                        onTap: () => _submit(_controller.text),
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: WpSpacing.xxs),
+                          child: Icon(
+                            LucideIcons.cornerDownLeft,
+                            size: 14,
+                            color: textMuted,
+                          ),
+                        ),
+                      ),
                     ),
                   ),
                 )


### PR DESCRIPTION
💡 What: Wrapped the `GestureDetector` on the tag input's submit icon with `Semantics`, `Tooltip`, and `MouseRegion`.
🎯 Why: Sighted users on desktop had no tooltip or cursor indication that the icon was clickable, and screen reader users were not informed that it was a button or what it did.
♿ Accessibility: The button now announces as a button with the label 'Add tag' to screen readers, shows a pointer cursor on hover, and displays a tooltip.

---
*PR created automatically by Jules for task [3301059411091888888](https://jules.google.com/task/3301059411091888888) started by @silvio-l*