### PR TITLE
🌱 Sprout: Add batch copy as markdown

### DIFF
--- a/.jules/sprout.md
+++ b/.jules/sprout.md
@@ -1,0 +1,3 @@
+## 2024-08-11 - Adding batch copy as markdown
+**Learning:** The `HistoryDetailPanel` has a single item action to "Copy as Markdown", but the multi-select batch action bar only had "Copy as Text".
+**Action:** Adding a "Copy as Markdown" multi-select batch action makes it consistent and is a helpful low-risk product improvement.

--- a/lib/features/history/history_page.dart
+++ b/lib/features/history/history_page.dart
@@ -456,6 +456,9 @@ class _HistoryPageState extends ConsumerState<HistoryPage> {
                   onBatchCopy: _selectedIds.isNotEmpty
                       ? () => _copySelectedEntries(filteredEntries)
                       : null,
+                  onBatchCopyMarkdown: _selectedIds.isNotEmpty
+                      ? () => _copySelectedEntriesAsMarkdown(filteredEntries)
+                      : null,
                   onExport: _selectedIds.isNotEmpty
                       ? () => _exportSelectedEntries(filteredEntries)
                       : null,
@@ -845,6 +848,46 @@ class _HistoryPageState extends ConsumerState<HistoryPage> {
     WpToast.show(
       context,
       message: L10n.of(context).historyCopiedToClipboard,
+      type: WpToastType.success,
+      duration: const Duration(seconds: 2),
+    );
+  }
+
+  /// Copy all selected entries' text formatted as Markdown to clipboard (joined by double newline).
+  void _copySelectedEntriesAsMarkdown(List<HistoryEntry> flat) {
+    final selected = flat.where((e) => _selectedIds.contains(e.id)).toList();
+    if (selected.isEmpty) return;
+
+    final md = StringBuffer();
+    for (var i = 0; i < selected.length; i++) {
+      final entry = selected[i];
+      md.writeln('# ${entry.title.isNotEmpty ? entry.title : "Untitled"}');
+      md.writeln();
+      md.writeln(entry.content);
+      md.writeln();
+      md.writeln('---');
+      md.writeln();
+      final tags = _parseTags(entry.tags);
+      if (tags.isNotEmpty) {
+        md.writeln('**Tags:** ${tags.map((t) => '#$t').join(', ')}');
+      }
+      md.writeln(
+        '**Date:** ${DateFormat.yMMMd().add_Hm().format(entry.timestamp)}',
+      );
+      if (entry.model.isNotEmpty) {
+        md.writeln('**Model:** ${entry.model}');
+      }
+      if (i < selected.length - 1) {
+        md.writeln();
+        md.writeln();
+      }
+    }
+
+    Clipboard.setData(ClipboardData(text: md.toString()));
+    if (!mounted) return;
+    WpToast.show(
+      context,
+      message: L10n.of(context).historyCopiedAsMarkdown,
       type: WpToastType.success,
       duration: const Duration(seconds: 2),
     );

--- a/lib/features/history/widgets/history_search_filter_bar.dart
+++ b/lib/features/history/widgets/history_search_filter_bar.dart
@@ -1076,6 +1076,7 @@ class HistoryMultiSelectBar extends StatelessWidget {
     this.totalCount,
     this.onMerge,
     this.onBatchCopy,
+    this.onBatchCopyMarkdown,
     this.onExport,
     this.onArchive,
     this.onDelete,
@@ -1091,6 +1092,7 @@ class HistoryMultiSelectBar extends StatelessWidget {
   final int? totalCount;
   final VoidCallback? onMerge;
   final VoidCallback? onBatchCopy;
+  final VoidCallback? onBatchCopyMarkdown;
   final VoidCallback? onExport;
   final VoidCallback? onArchive;
   final VoidCallback? onDelete;
@@ -1202,6 +1204,14 @@ class HistoryMultiSelectBar extends StatelessWidget {
                       ),
                       isDark: isDark,
                       onTap: onBatchCopy!,
+                    ),
+                  if (onBatchCopyMarkdown != null)
+                    // loam-ignore: a11y-interactive-semantics – semantics provided in _HistoryMultiSelectActionState.build
+                    HistoryMultiSelectAction(
+                      icon: LucideIcons.fileText,
+                      label: l10n.historyCopyAsMarkdown,
+                      isDark: isDark,
+                      onTap: onBatchCopyMarkdown!,
                     ),
                   if (onExport != null)
                     // loam-ignore: a11y-interactive-semantics – semantics provided in _HistoryMultiSelectActionState.build


### PR DESCRIPTION
**🌱 What**
Added a "Copy as Markdown" action to the multi-select batch actions bar in the history view.

**💡 Why**
The individual entry detail panel already has a "Copy as Markdown" option in its overflow menu, but when selecting multiple items, users could only batch copy as plain text or export them. Adding batch "Copy as Markdown" fixes a consistency gap and provides a small quality-of-life workflow improvement for users wanting to easily paste multiple transcripts into Markdown-supported editors.

**🧩 Why this is low-risk**
The change reuses the existing `HistoryMultiSelectAction` component and existing localization strings (`historyCopyAsMarkdown`, `historyCopiedAsMarkdown`). It introduces no new dependencies, requires no architectural changes, and merely aggregates the same Markdown formatting logic that was already proven for single entries into a loop. 

**🔧 Implementation**
Added an `onBatchCopyMarkdown` callback to `HistoryMultiSelectBar` and instantiated a new action using the `LucideIcons.fileText` icon. Hooked it up in `HistoryPage` with a new `_copySelectedEntriesAsMarkdown` method that formats multiple selected items just like `_copyAsMarkdown` does for single ones, separated by newlines.

**✅ Verification**
- Verified the correct UI placement via code inspection (`history_search_filter_bar.dart`).
- Verified `LucideIcons.fileText` is the identical icon used in the detail view.
- Verified localization strings were pre-existing in `.arb` files and generated correctly.
- Addressed memory instructions to document learning in `.jules/sprout.md`.

---
*PR created automatically by Jules for task [6787396021422131853](https://jules.google.com/task/6787396021422131853) started by @silvio-l*