### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in macOS update script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `MacUpdateInstaller` embedded dynamic inputs (like the DMG path) directly into a generated shell script using fragile manual quoting (`_shq`), which is susceptible to command injection if quotes can be bypassed.
 **Learning:** Shell script generation via string interpolation is an anti-pattern. Even with manual escaping, it is difficult to secure perfectly and introduces a wide attack surface for malicious payloads.
 **Prevention:** Always parameterize shell commands. Use positional arguments (``, ``) in scripts and pass dynamic values via the native process arguments array (`Process.start`), which hands them directly to the OS without shell parsing.
+
+## 2024-05-18 - Prevent Command Injection via heredoc expansion in macOS Update Script
+**Vulnerability:** The macOS update script generated an inner script using an unquoted heredoc (`<<WPINNER`), causing the shell to expand variables like `$STAGE` before the inner script ran. This exposed the execution path to command injection, particularly concerning as the script runs with `osascript` administrator privileges, leading to potential Local Privilege Escalation (LPE).
+**Learning:** Even when external variables are passed correctly to an outer script, if that script generates another script via heredoc, the heredoc delimiter must be quoted (`<<'EOF'`) to prevent premature variable expansion.
+**Prevention:** Always quote heredoc delimiters when generating scripts. Pass required dynamic data to the generated script via positional arguments, and when using `osascript`, handle those arguments via `on run argv` and AppleScript's `quoted form of` command to ensure safe parameterization.

--- a/lib/services/update/mac_update_installer.dart
+++ b/lib/services/update/mac_update_installer.dart
@@ -88,20 +88,25 @@ if [ ! -d "\$SRC" ] || [ ! -f "\$SRC/Contents/Info.plist" ]; then
   exit 13
 fi
 
-# 4. Stage + atomic swap as a self-contained inner script with concrete paths,
-#    so it runs identically whether direct or under one admin prompt.
+# 4. Stage + atomic swap as a self-contained inner script, parameterized via
+#    positional arguments so it runs identically whether direct or under one admin
+#    prompt, and avoids command injection from path string interpolation.
 STAGE="\${TARGET}.wp-new-\$\$"
 BACKUP="\${TARGET}.wp-old-\$\$"
 INNER="\$(mktemp /tmp/wp-swap.XXXXXX)"
-cat >"\$INNER" <<WPINNER
+cat >"\$INNER" <<'WPINNER'
 #!/bin/sh
 set -e
-rm -rf "\$STAGE" "\$BACKUP"
-/usr/bin/ditto "\$SRC" "\$STAGE"
-/usr/bin/xattr -dr com.apple.quarantine "\$STAGE" 2>/dev/null || true
-mv "\$TARGET" "\$BACKUP"
-mv "\$STAGE" "\$TARGET"
-rm -rf "\$BACKUP"
+INNER_SRC="\$1"
+INNER_STAGE="\$2"
+INNER_TARGET="\$3"
+INNER_BACKUP="\$4"
+rm -rf "\$INNER_STAGE" "\$INNER_BACKUP"
+/usr/bin/ditto "\$INNER_SRC" "\$INNER_STAGE"
+/usr/bin/xattr -dr com.apple.quarantine "\$INNER_STAGE" 2>/dev/null || true
+mv "\$INNER_TARGET" "\$INNER_BACKUP"
+mv "\$INNER_STAGE" "\$INNER_TARGET"
+rm -rf "\$INNER_BACKUP"
 WPINNER
 chmod +x "\$INNER"
 
@@ -111,12 +116,12 @@ chmod +x "\$INNER"
 PARENT_DIR="\$(dirname "\$TARGET")"
 if [ -w "\$PARENT_DIR" ] && { [ ! -e "\$TARGET" ] || [ -w "\$TARGET" ]; }; then
   echo "[wp-update] writable target — direct swap"
-  if ! /bin/sh "\$INNER"; then
+  if ! /bin/sh "\$INNER" "\$SRC" "\$STAGE" "\$TARGET" "\$BACKUP"; then
     echo "[wp-update] ERROR: swap failed"; detach; rm -f "\$INNER"; exit 14
   fi
 else
   echo "[wp-update] non-writable target — escalating via admin prompt"
-  if ! /usr/bin/osascript -e "do shell script \\"/bin/sh \$INNER\\" with administrator privileges"; then
+  if ! /usr/bin/osascript -e "on run argv" -e "do shell script \\"/bin/sh \\" & quoted form of item 1 of argv & \\" \\" & quoted form of item 2 of argv & \\" \\" & quoted form of item 3 of argv & \\" \\" & quoted form of item 4 of argv & \\" \\" & quoted form of item 5 of argv with administrator privileges" -e "end run" "\$INNER" "\$SRC" "\$STAGE" "\$TARGET" "\$BACKUP"; then
     echo "[wp-update] ERROR: escalation declined/failed — install untouched"
     detach; rm -f "\$INNER"; exit 15
   fi

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.2.66+34
 
 environment:
-  sdk: ^3.12.0
+  sdk: ">=3.11.0 <4.0.0"
   flutter: ">=3.44.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.2.66+34
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
+  sdk: ^3.12.0
   flutter: ">=3.44.0"
 
 dependencies:

--- a/test/services/mac_update_test.dart
+++ b/test/services/mac_update_test.dart
@@ -62,12 +62,12 @@ void main() {
       final s = build();
       // ditto stages a copy, then two renames move it into place atomically.
       expect(s, contains('/usr/bin/ditto'));
-      expect(s, contains('mv "\$TARGET" "\$BACKUP"'));
-      expect(s, contains('mv "\$STAGE" "\$TARGET"'));
+      expect(s, contains('mv "\$INNER_TARGET" "\$INNER_BACKUP"'));
+      expect(s, contains('mv "\$INNER_STAGE" "\$INNER_TARGET"'));
     });
 
     test('strips quarantine from the staged bundle', () {
-      expect(build(), contains('/usr/bin/xattr -dr com.apple.quarantine'));
+      expect(build(), contains('/usr/bin/xattr -dr com.apple.quarantine "\$INNER_STAGE"'));
     });
 
     test('escalates once via osascript when the target is not writable', () {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The macOS update helper script (`lib/services/update/mac_update_installer.dart`) used an unquoted here-doc (`<<WPINNER`) to generate an inner shell script. This caused string interpolation and variable expansion to occur within the inner script before it was saved. If an attacker could craft malicious directory paths (for example, by placing the WhisPaste app in a directory with shell metacharacters and quotes), they could achieve command injection. Because the script elevates privileges using `osascript ... with administrator privileges` for non-writable targets, this constitutes a Local Privilege Escalation (LPE) vulnerability.
🎯 **Impact:** Malicious code could be executed with root/administrator privileges on the user's system during an application update.
🔧 **Fix:** Changed the here-doc to a quoted format (`<<'WPINNER'`) to disable variable expansion. Parameterized the inner shell script to accept its path arguments positionally (`$1`, `$2`, `$3`, `$4`). Modified the `osascript` AppleScript invocation to securely accept these inputs via `on run argv` and safely escape them using `quoted form of item X of argv` before appending them to the `/bin/sh` command.
✅ **Verification:** Verified that the outer script accurately quotes and escapes variables when passed into the AppleScript context and inner shell execution, eliminating the string interpolation risk. Note: Running the test suite locally in the sandbox failed due to SDK version requirements in the `pubspec.yaml`, but the patch logic has been thoroughly reviewed.

---
*PR created automatically by Jules for task [2667561399640931579](https://jules.google.com/task/2667561399640931579) started by @silvio-l*