### PR TITLE
🎨 Palette: Add Semantics to STT Model Selector Tiers

### DIFF
--- a/lib/features/settings/stt_model_selector.dart
+++ b/lib/features/settings/stt_model_selector.dart
@@ -297,79 +297,83 @@ class _TierRowState extends State<_TierRow> {
       cursor: isSelectable
           ? SystemMouseCursors.click
           : SystemMouseCursors.basic,
-      child: GestureDetector(
-        onTap: isSelectable ? widget.onSelect : null,
-        behavior: HitTestBehavior.opaque,
-        child: AnimatedContainer(
-          duration: WpMotion.durationFor(context, WpMotion.hoverIn),
-          curve: WpMotion.defaultCurve,
-          // 1px margin keeps adjacent rows' selection borders from touching.
-          margin: const EdgeInsets.symmetric(vertical: 1),
-          padding: const EdgeInsets.symmetric(
-            horizontal: WpSpacing.sm,
-            vertical: WpSpacing.sm,
-          ),
-          decoration: BoxDecoration(
-            color: widget.isCurrentTier || _isDownloading
-                ? accentButtonFill
-                : _isHovered && isSelectable
-                ? hoverBg
-                : Colors.transparent,
-            borderRadius: BorderRadius.circular(WpRadius.sm),
-            border: widget.isCurrentTier || _isDownloading
-                ? Border.all(color: accentBorder30)
-                : null,
-          ),
-          child: Column(
-            children: [
-              Row(
-                children: [
-                  // Tier icon with status indicator
-                  _StatusIcon(
-                    isDownloaded: _isDownloaded,
-                    isActive: _isDownloading,
-                    phase: _phase,
-                    icon: _tierIcon,
-                    accent: accent,
-                    success: success,
-                    muted: textMuted,
-                  ),
-                  const SizedBox(width: WpSpacing.sm),
-                  // Tier info
-                  Expanded(
-                    child: _TierRowInfo(
-                      tier: widget.tier,
-                      label: _tierLabel(widget.l10n),
-                      desc: _tierDesc(widget.l10n),
-                      isRecommended: widget.isRecommended,
+      child: Semantics(
+        button: isSelectable,
+        label: isSelectable ? _tierLabel(widget.l10n) : null,
+        child: GestureDetector(
+          onTap: isSelectable ? widget.onSelect : null,
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedContainer(
+            duration: WpMotion.durationFor(context, WpMotion.hoverIn),
+            curve: WpMotion.defaultCurve,
+            // 1px margin keeps adjacent rows' selection borders from touching.
+            margin: const EdgeInsets.symmetric(vertical: 1),
+            padding: const EdgeInsets.symmetric(
+              horizontal: WpSpacing.sm,
+              vertical: WpSpacing.sm,
+            ),
+            decoration: BoxDecoration(
+              color: widget.isCurrentTier || _isDownloading
+                  ? accentButtonFill
+                  : _isHovered && isSelectable
+                  ? hoverBg
+                  : Colors.transparent,
+              borderRadius: BorderRadius.circular(WpRadius.sm),
+              border: widget.isCurrentTier || _isDownloading
+                  ? Border.all(color: accentBorder30)
+                  : null,
+            ),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    // Tier icon with status indicator
+                    _StatusIcon(
                       isDownloaded: _isDownloaded,
-                      isBenchmarking: widget.isBenchmarking,
-                      infoMessage: infoMessage,
-                      infoColor: infoColor,
-                      performance: infoPerformance,
+                      isActive: _isDownloading,
+                      phase: _phase,
+                      icon: _tierIcon,
+                      accent: accent,
+                      success: success,
+                      muted: textMuted,
+                    ),
+                    const SizedBox(width: WpSpacing.sm),
+                    // Tier info
+                    Expanded(
+                      child: _TierRowInfo(
+                        tier: widget.tier,
+                        label: _tierLabel(widget.l10n),
+                        desc: _tierDesc(widget.l10n),
+                        isRecommended: widget.isRecommended,
+                        isDownloaded: _isDownloaded,
+                        isBenchmarking: widget.isBenchmarking,
+                        infoMessage: infoMessage,
+                        infoColor: infoColor,
+                        performance: infoPerformance,
+                        isDark: widget.isDark,
+                        l10n: widget.l10n,
+                        accent: accent,
+                        textMuted: textMuted,
+                        success: success,
+                      ),
+                    ),
+                    // Action
+                    _buildAction(accent, textMuted),
+                  ],
+                ),
+                // Progress bar + status text
+                if (_isDownloading && widget.downloadState.isBusy)
+                  Padding(
+                    padding: const EdgeInsets.only(top: WpSpacing.xs),
+                    child: _DownloadProgressInfo(
+                      downloadState: widget.downloadState,
+                      accent: accent,
                       isDark: widget.isDark,
                       l10n: widget.l10n,
-                      accent: accent,
-                      textMuted: textMuted,
-                      success: success,
                     ),
                   ),
-                  // Action
-                  _buildAction(accent, textMuted),
-                ],
-              ),
-              // Progress bar + status text
-              if (_isDownloading && widget.downloadState.isBusy)
-                Padding(
-                  padding: const EdgeInsets.only(top: WpSpacing.xs),
-                  child: _DownloadProgressInfo(
-                    downloadState: widget.downloadState,
-                    accent: accent,
-                    isDark: widget.isDark,
-                    l10n: widget.l10n,
-                  ),
-                ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
💡 **What:** Wrapped the `GestureDetector` used for selecting AI model tiers in `stt_model_selector.dart` with a `Semantics` widget.
🎯 **Why:** To ensure that visually impaired users using screen readers can properly interact with and identify the different model tiers available for download. Previously, the `GestureDetector` did not announce itself as interactive or provide a label.
♿ **Accessibility:** Added `Semantics(button: isSelectable, label: isSelectable ? _tierLabel(widget.l10n) : null)` so screen readers announce it as a button with the tier's name.

---
*PR created automatically by Jules for task [15195296949820583629](https://jules.google.com/task/15195296949820583629) started by @silvio-l*