### PR TITLE
🎨 Palette: Add tooltip and pointer cursor to dismiss button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-13 - Added Tooltip to WpDiscoverabilityHint dismiss button
+**Learning:** When using a bare `GestureDetector` as an icon button instead of `IconButton`, you miss out on desktop/web UX essentials like a pointer cursor on hover and a tooltip. Adding `Tooltip` and `MouseRegion` makes it feel like a real button.
+**Action:** Always wrap interactive icon-only elements (that aren't natively buttons) in `MouseRegion(cursor: SystemMouseCursors.click)` and `Tooltip` on desktop apps, and ensure they have `Semantics` for screen readers.

--- a/lib/widgets/wp_discoverability_hint.dart
+++ b/lib/widgets/wp_discoverability_hint.dart
@@ -108,12 +108,18 @@ class _WpDiscoverabilityHintState extends State<WpDiscoverabilityHint> {
           Semantics(
             label: L10n.of(context).hintDismiss,
             button: true,
-            child: GestureDetector(
-              onTap: _dismiss,
-              child: const Icon(
-                LucideIcons.x,
-                size: WpIconSize.xs,
-                color: textMuted,
+            child: Tooltip(
+              message: L10n.of(context).hintDismiss,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: _dismiss,
+                  child: const Icon(
+                    LucideIcons.x,
+                    size: WpIconSize.xs,
+                    color: textMuted,
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
💡 What: Wrapped the `GestureDetector` dismiss button in `WpDiscoverabilityHint` with `Tooltip` and `MouseRegion`.
🎯 Why: Without these, the dismiss `x` icon didn't have a tooltip to explain its function or a pointer cursor to indicate interactivity on desktop. This change makes it feel like a standard interactive button.
📸 Before/After: Before, hovering over the X didn't change the cursor and provided no tooltip. Now, it shows a pointer and "Dismiss" tooltip.
♿ Accessibility: The dismiss button already had `Semantics(button: true)` and label; added tooltip text to mirror the label.

---
*PR created automatically by Jules for task [7681000185120114744](https://jules.google.com/task/7681000185120114744) started by @silvio-l*