### PR TITLE
⚡ Bolt: Optimize search list filtering with RegExp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Case-insensitive filtering in Dart tight loops
 **Learning:** Using `String.toLowerCase()` inside a tight `where` loop in Dart allocates a new String for every item evaluated. In lists of strings like search results or tag lists, this creates massive GC pressure.
 **Action:** Use a precompiled `RegExp` with `caseSensitive: false` before the loop, and use `searchRegex.hasMatch(item)` inside the loop instead.
+## 2025-02-18 - String allocations in tight loops
+**Learning:** `toLowerCase()` allocates new strings for every item evaluated during search filtering loops, which is wasteful and hurts performance compared to regex.
+**Action:** Use a precompiled `RegExp` with `caseSensitive: false` outside the loop when doing list filtering, instead of dynamically lowercasing properties inside the loop.

--- a/lib/features/replacements/replacements_page.dart
+++ b/lib/features/replacements/replacements_page.dart
@@ -196,8 +196,8 @@ class _ReplacementsPageState extends ConsumerState<ReplacementsPage> {
       ),
       asyncAll: ref.watch(replacementsProvider),
       searchMatches: (r, q) =>
-          r.triggers.any((t) => t.toLowerCase().contains(q)) ||
-          r.replacement.toLowerCase().contains(q),
+          r.triggers.any((t) => q.hasMatch(t)) ||
+          q.hasMatch(r.replacement),
       searchHint: l10n.replacementsSearch,
       searchFieldLabel: l10n.replacementsSearchFieldLabel,
       addLabel: l10n.replacementsAdd,

--- a/lib/features/snippets/snippets_page.dart
+++ b/lib/features/snippets/snippets_page.dart
@@ -165,7 +165,7 @@ class _SnippetsPageState extends ConsumerState<SnippetsPage> {
       ),
       asyncAll: ref.watch(snippetsProvider),
       searchMatches: (s, q) =>
-          s.title.toLowerCase().contains(q) || s.body.toLowerCase().contains(q),
+          q.hasMatch(s.title) || q.hasMatch(s.body),
       searchHint: l10n.snippetsSearch,
       searchFieldLabel: l10n.snippetsSearchFieldLabel,
       addLabel: l10n.snippetsAdd,

--- a/lib/widgets/searchable_list_page.dart
+++ b/lib/widgets/searchable_list_page.dart
@@ -52,8 +52,8 @@ class WpSearchableListPage<T> extends StatefulWidget {
   final AsyncValue<List<T>> asyncAll;
 
   /// Whether [item] matches the search query. Called only for non-empty
-  /// queries; `query` is already lowercased.
-  final bool Function(T item, String query) searchMatches;
+  /// queries; `query` is pre-compiled as a case-insensitive RegExp.
+  final bool Function(T item, RegExp query) searchMatches;
 
   /// Hint text of the toolbar search field.
   final String searchHint;
@@ -270,7 +270,10 @@ class _WpSearchableListPageState<T> extends State<WpSearchableListPage<T>> {
 
   List<T> _filtered(List<T> all) {
     if (_searchQuery.isEmpty) return all;
-    final q = _searchQuery.toLowerCase();
+    // ⚡ Bolt: Precompile a case-insensitive RegExp outside the loop
+    // instead of calling toLowerCase() on every item inside the loop.
+    // This reduces memory allocation overhead in tight loops.
+    final q = RegExp(RegExp.escape(_searchQuery), caseSensitive: false);
     return all.where((item) => widget.searchMatches(item, q)).toList();
   }
 


### PR DESCRIPTION
💡 What: Swapped out `toLowerCase().contains()` string filtering with a pre-compiled `RegExp(..., caseSensitive: false)` check during list searches. Updated `WpSearchableListPage` and its call-sites (`SnippetsPage` and `ReplacementsPage`) to use the new matching callback.
🎯 Why: `toLowerCase()` creates a brand-new String object in memory for every single evaluation during a `.where()` loop. For search-as-you-type implementations on lists, this results in significant unnecessary memory churn and GC pressure. Precompiling a regular expression avoids all that allocation overhead.
📊 Impact: Reduces memory allocation by O(N) strings per keystroke during search in Snippets and Replacements lists. Less GC pressure means fewer potential UI stutters.
🔬 Measurement: Open Snippets or Replacements page, type rapidly in the search field, and observe memory allocations via DevTools (or just enjoy smoother search).

---
*PR created automatically by Jules for task [6717760010259672298](https://jules.google.com/task/6717760010259672298) started by @silvio-l*