### PR TITLE
🎨 Palette: [Accessibility] Announce interactive text as buttons for screen readers

### DIFF
--- a/lib/features/history/widgets/history_detail_panel.dart
+++ b/lib/features/history/widgets/history_detail_panel.dart
@@ -623,6 +623,7 @@ class _DetailPanelHeader extends StatelessWidget {
                         Expanded(
                           child: Semantics(
                             button: !isTrashView,
+                            label: isTrashView ? null : l10n.historyEditTitle,
                             onTapHint: isTrashView
                                 ? null
                                 : l10n.historyEditTitle,
@@ -929,6 +930,7 @@ class _DetailTranscriptZone extends StatelessWidget {
                       )
                     : Semantics(
                         button: !isTrashView,
+                        label: isTrashView ? null : l10n.historyEditTranscript,
                         // Same trash-view rule as the title above: the
                         // transcript is read-only here, so it must not offer
                         // "Edit transcript" on hover next to a tap that does

--- a/test/features/history/history_markdown_shortcuts_test.dart
+++ b/test/features/history/history_markdown_shortcuts_test.dart
@@ -90,7 +90,7 @@ Future<void> _openTranscriptEditor(WidgetTester tester) async {
 
   // The read view of the transcript carries the "Edit transcript" tooltip and
   // opens edit mode on tap.
-  final readView = find.byTooltip(l10n.historyEditTranscript).first;
+  final readView = find.bySemanticsLabel(l10n.historyEditTranscript).first;
   await tester.ensureVisible(readView);
   await tester.pumpAndSettle();
   await tester.tap(readView, warnIfMissed: false);


### PR DESCRIPTION
* 💡 **What:** Added the `label` parameter to `Semantics` widgets that wrap the title and transcript `GestureDetector`s in `HistoryDetailPanel`.
* 🎯 **Why:** Interactive text widgets handled via `GestureDetector` rely on tooltips for sighted users but do not inherently announce themselves as interactive to screen readers, making them difficult to discover for users of assistive technology.
* 📸 **Before/After:** No visual changes.
* ♿ **Accessibility:** Screen reader users will now hear the localized labels "Edit title" and "Edit transcript" when focusing on these text areas.

---
*PR created automatically by Jules for task [859589214360582013](https://jules.google.com/task/859589214360582013) started by @silvio-l*