### PR TITLE
⚡ Bolt: optimize searchable list loop with compiled RegExp

### DIFF
--- a/lib/features/replacements/replacements_page.dart
+++ b/lib/features/replacements/replacements_page.dart
@@ -196,8 +196,8 @@ class _ReplacementsPageState extends ConsumerState<ReplacementsPage> {
       ),
       asyncAll: ref.watch(replacementsProvider),
       searchMatches: (r, q) =>
-          r.triggers.any((t) => t.toLowerCase().contains(q)) ||
-          r.replacement.toLowerCase().contains(q),
+          r.triggers.any((t) => q.hasMatch(t)) ||
+          q.hasMatch(r.replacement),
       searchHint: l10n.replacementsSearch,
       searchFieldLabel: l10n.replacementsSearchFieldLabel,
       addLabel: l10n.replacementsAdd,

--- a/lib/features/snippets/snippets_page.dart
+++ b/lib/features/snippets/snippets_page.dart
@@ -166,7 +166,7 @@ class _SnippetsPageState extends ConsumerState<SnippetsPage> {
       ),
       asyncAll: ref.watch(snippetsProvider),
       searchMatches: (s, q) =>
-          s.title.toLowerCase().contains(q) || s.body.toLowerCase().contains(q),
+          q.hasMatch(s.title) || q.hasMatch(s.body),
       searchHint: l10n.snippetsSearch,
       searchFieldLabel: l10n.snippetsSearchFieldLabel,
       addLabel: l10n.snippetsAdd,

--- a/lib/widgets/searchable_list_page.dart
+++ b/lib/widgets/searchable_list_page.dart
@@ -52,8 +52,8 @@ class WpSearchableListPage<T> extends StatefulWidget {
   final AsyncValue<List<T>> asyncAll;
 
   /// Whether [item] matches the search query. Called only for non-empty
-  /// queries; `query` is already lowercased.
-  final bool Function(T item, String query) searchMatches;
+  /// queries; `query` is compiled into a case-insensitive `RegExp`.
+  final bool Function(T item, RegExp query) searchMatches;
 
   /// Hint text of the toolbar search field.
   final String searchHint;
@@ -270,7 +270,9 @@ class _WpSearchableListPageState<T> extends State<WpSearchableListPage<T>> {
 
   List<T> _filtered(List<T> all) {
     if (_searchQuery.isEmpty) return all;
-    final q = _searchQuery.toLowerCase();
+    // ⚡ Bolt: compile RegExp once before the tight loop to avoid massive GC
+    // pressure from String.toLowerCase() string allocations per evaluated item.
+    final q = RegExp(RegExp.escape(_searchQuery), caseSensitive: false);
     return all.where((item) => widget.searchMatches(item, q)).toList();
   }
 


### PR DESCRIPTION
💡 **What:** 
Replaced `String.toLowerCase()` calls inside the tight loop `Iterable.where` for `WpSearchableListPage` filtering with a pre-compiled case-insensitive `RegExp`. The matching logic in `snippets_page.dart` and `replacements_page.dart` was updated to use `RegExp.hasMatch`.

🎯 **Why:** 
When searching through large lists of text (like Replacements or Snippets), using `.toLowerCase()` inside a `.where` loop allocates a brand new String in memory for every field on every item for every character typed in the search bar. This introduces unnecessary Garbage Collection (GC) pressure and micro-stutters during typing. Compiling a `RegExp` once per keystroke avoids this per-item allocation overhead entirely.

📊 **Impact:** 
Significantly reduces memory churn and GC spikes while searching through long snippet or replacement lists. Memory allocations scale `O(1)` per keystroke instead of `O(N)` where N is the number of items multiplied by the number of searchable fields. 

🔬 **Measurement:** 
Open the Replacements or Snippets page, add a large number of items, and type rapidly into the search field. Memory profiling in Dart DevTools will show drastically fewer temporary `String` allocations during the search query updates.

---
*PR created automatically by Jules for task [2873465948070184008](https://jules.google.com/task/2873465948070184008) started by @silvio-l*