### PR TITLE
🎨 Palette: Add accessibility semantics to History Notes section header

### DIFF
--- a/lib/features/history/widgets/history_notes_section.dart
+++ b/lib/features/history/widgets/history_notes_section.dart
@@ -138,56 +138,71 @@ class HistoryNotesSectionState extends ConsumerState<HistoryNotesSection> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Header row — clickable to start adding a note
-            GestureDetector(
-              onTap: _isAdding ? null : () => setState(() => _isAdding = true),
-              behavior: HitTestBehavior.opaque,
-              child: Row(
-                children: [
-                  const Icon(
-                    LucideIcons.stickyNote,
-                    size: WpIconSize.sm,
-                    color: accent,
-                  ),
-                  const SizedBox(width: WpSpacing.xs),
-                  Flexible(
-                    child: Text(
-                      noteList.isEmpty
-                          ? l10n.historyAddNote
-                          : '${l10n.historyNotes} (${noteList.length})',
-                      style: const TextStyle(
-                        fontSize: WpTypography.body,
-                        fontWeight: FontWeight.w600,
-                        color: textSecondary,
-                        letterSpacing: 0.3,
+            Semantics(
+              button: true,
+              label: l10n.historyAddNote,
+              enabled: !_isAdding,
+              child: MouseRegion(
+                cursor: _isAdding
+                    ? SystemMouseCursors.basic
+                    : SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: _isAdding
+                      ? null
+                      : () => setState(() => _isAdding = true),
+                  behavior: HitTestBehavior.opaque,
+                  child: Row(
+                    children: [
+                      const Icon(
+                        LucideIcons.stickyNote,
+                        size: WpIconSize.sm,
+                        color: accent,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  const SizedBox(width: WpSpacing.sm),
-                  VoiceNoteButton(entryId: widget.entryId),
-                  const SizedBox(width: WpSpacing.xxs),
-                  if (!_isAdding)
-                    Semantics(
-                      label: l10n.historyAddNote,
-                      button: true,
-                      child: Tooltip(
-                        message: l10n.historyAddNote,
-                        child: InkWell(
-                          onTap: () => setState(() => _isAdding = true),
-                          borderRadius: WpRadius.borderSm,
-                          child: const Padding(
-                            padding: EdgeInsets.all(WpSpacing.xs),
-                            child: Icon(
-                              LucideIcons.plus,
-                              size: WpIconSize.md,
-                              color: accent,
+                      const SizedBox(width: WpSpacing.xs),
+                      Flexible(
+                        child: Text(
+                          noteList.isEmpty
+                              ? l10n.historyAddNote
+                              : '${l10n.historyNotes} (${noteList.length})',
+                          style: const TextStyle(
+                            fontSize: WpTypography.body,
+                            fontWeight: FontWeight.w600,
+                            color: textSecondary,
+                            letterSpacing: 0.3,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: WpSpacing.sm),
+                      VoiceNoteButton(entryId: widget.entryId),
+                      const SizedBox(width: WpSpacing.xxs),
+                      if (!_isAdding)
+                        // The 'Add note' button is functionally identical to tapping the
+                        // row, but keeps its own semantics node to remain discoverable
+                        // as a discrete action target for screen reader navigation.
+                        Semantics(
+                          label: l10n.historyAddNote,
+                          button: true,
+                          child: Tooltip(
+                            message: l10n.historyAddNote,
+                            child: InkWell(
+                              onTap: () => setState(() => _isAdding = true),
+                              borderRadius: WpRadius.borderSm,
+                              child: const Padding(
+                                padding: EdgeInsets.all(WpSpacing.xs),
+                                child: Icon(
+                                  LucideIcons.plus,
+                                  size: WpIconSize.md,
+                                  color: accent,
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ),
-                ],
+                    ],
+                  ),
+                ),
               ),
             ),
             // Add note input


### PR DESCRIPTION
💡 **What**: Added `Semantics(button: true, label: ...)` and `MouseRegion(cursor: SystemMouseCursors.click)` to the `GestureDetector` in the History Notes section header.
🎯 **Why**: The header acts as an interactive button to start adding a note. Without `Semantics`, screen readers do not announce it as a button, making it undiscoverable. Without `MouseRegion`, sighted mouse users receive no hover feedback that the area is clickable.
📸 **Before/After**: Sighted users will now see a pointer cursor when hovering the row. Screen reader users will hear "Add note, button".
♿ **Accessibility**: Significant improvement for screen reader discoverability and sighted pointer feedback on an interactive text element.

---
*PR created automatically by Jules for task [4055959490551013024](https://jules.google.com/task/4055959490551013024) started by @silvio-l*