### PR TITLE
🎨 Palette: Make discoverability hint dismissible via keyboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-21 - Keyboard Accessibility with WpFocusRing
+**Learning:** In this application, a bare `GestureDetector` inside a `Semantics(button: true)` is reachable by screen readers but remains inaccessible to keyboard users (no Tab focus or Enter activation).
+**Action:** Always replace bare `GestureDetector` interactive elements with an `InkWell` wrapped in a `WpFocusRing`, sharing a `FocusNode` to provide complete keyboard accessibility and visual focus states.

--- a/lib/widgets/wp_discoverability_hint.dart
+++ b/lib/widgets/wp_discoverability_hint.dart
@@ -20,6 +20,7 @@ import '../core/l10n/generated/app_localizations.dart';
 import '../core/logging/app_logger.dart';
 import '../core/theme/colors.dart';
 import '../core/theme/tokens.dart';
+import 'wp_focus_ring.dart';
 
 final _log = AppLogger('DiscoverabilityHint');
 
@@ -48,10 +49,20 @@ class _WpDiscoverabilityHintState extends State<WpDiscoverabilityHint> {
   // avoid a one-frame flash before the real (possibly "seen") state is known.
   bool? _seen;
 
+  final FocusNode _dismissFocusNode = FocusNode(
+    debugLabel: 'DiscoverabilityHintDismiss',
+  );
+
   @override
   void initState() {
     super.initState();
     _load();
+  }
+
+  @override
+  void dispose() {
+    _dismissFocusNode.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -112,12 +123,23 @@ class _WpDiscoverabilityHintState extends State<WpDiscoverabilityHint> {
               message: L10n.of(context).hintDismiss,
               child: MouseRegion(
                 cursor: SystemMouseCursors.click,
-                child: GestureDetector(
-                  onTap: _dismiss,
-                  child: const Icon(
-                    LucideIcons.x,
-                    size: WpIconSize.xs,
-                    color: textMuted,
+                child: WpFocusRing(
+                  focusNode: _dismissFocusNode,
+                  radius: WpRadius.sm,
+                  child: InkWell(
+                    onTap: _dismiss,
+                    focusNode: _dismissFocusNode,
+                    borderRadius: BorderRadius.circular(WpRadius.sm),
+                    // WpFocusRing owns all focus visuals — suppress InkWell's own.
+                    focusColor: Colors.transparent,
+                    hoverColor: Colors.transparent,
+                    splashColor: Colors.transparent,
+                    highlightColor: Colors.transparent,
+                    child: const Icon(
+                      LucideIcons.x,
+                      size: WpIconSize.xs,
+                      color: textMuted,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
💡 **What:** Replaced the `GestureDetector` that controls the dismiss button on `WpDiscoverabilityHint` with a `WpFocusRing` wrapping an `InkWell`.
🎯 **Why:** The previous implementation used a bare `GestureDetector`, which is pointer-only. Screen reader users and keyboard-only users could not tab to or activate the dismiss button, breaking the accessibility promise of the application.
📸 **Before/After:** Visually identical except keyboard navigation now displays the app's default focus ring around the dismiss icon.
♿ **Accessibility:** Added a `FocusNode` tied to the new structure. This enables Tab indexing, Enter/Space activation, and correct semantic handling without double-announcing the label.

---
*PR created automatically by Jules for task [1856277152667098713](https://jules.google.com/task/1856277152667098713) started by @silvio-l*