### PR TITLE
⚡ Bolt: Use precompiled RegExp for case-insensitive filtering in side panel rows

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@ was already rejected, because rejected PRs never touch `dev`.
 ## 2024-05-18 - Case-insensitive filtering in Dart tight loops
 **Learning:** Using `String.toLowerCase()` inside a tight `where` loop in Dart allocates a new String for every item evaluated. In lists of strings like search results or tag lists, this creates massive GC pressure.
 **Action:** Use a precompiled `RegExp` with `caseSensitive: false` before the loop, and use `searchRegex.hasMatch(item)` inside the loop instead. Note: Do not apply to `WpSearchableListPage._filtered`.
+
+## 2024-05-18 - Isolated Dart Scripts in the Sandbox
+**Learning:** In the sandbox environment, `flutter test` and `dart run` often fail on existing files due to package resolution issues caused by Dart SDK version mismatch with the `pubspec.yaml` constraint.
+**Action:** When needing to run simple isolated tests or benchmarks without `package:` imports, create a temporary `.dart` script in a subfolder like `tool/` using relative imports (e.g. `import '../lib/...'`) instead of `package:` imports.

--- a/lib/services/side_panel/side_panel_row_filter.dart
+++ b/lib/services/side_panel/side_panel_row_filter.dart
@@ -24,11 +24,13 @@ List<SidePanelRow> filterSidePanelRows(List<SidePanelRow> rows, String query) {
   final trimmed = query.trim();
   if (trimmed.isEmpty) return rows;
 
-  final needle = trimmed.toLowerCase();
+  // Optimisation: A precompiled case-insensitive RegExp avoids allocating
+  // a new String for every item's title/subtitle via .toLowerCase() in the loop.
+  // RegExp.escape prevents crashes from special characters in the search query.
+  final searchRegex = RegExp(RegExp.escape(trimmed), caseSensitive: false);
   return [
     for (final row in rows)
-      if (row.title.toLowerCase().contains(needle) ||
-          row.subtitle.toLowerCase().contains(needle))
+      if (searchRegex.hasMatch(row.title) || searchRegex.hasMatch(row.subtitle))
         row,
   ];
 }


### PR DESCRIPTION
💡 **What:** Replaced `String.toLowerCase().contains()` with a precompiled `RegExp` initialized with `caseSensitive: false` before the `for` loop in `filterSidePanelRows`. Added `RegExp.escape()` to sanitize inputs.

🎯 **Why:** The previous code called `row.title.toLowerCase()` and `row.subtitle.toLowerCase()` inside a tight iteration loop over all side panel rows. Since `.toLowerCase()` allocates a new `String` for every evaluation, it generated significant Garbage Collection (GC) pressure on each keystroke for large lists. Using a precompiled case-insensitive regex avoids these allocations. (Note: As learned from `.jules/bolt.md`, this is applicable here since it does not run on `WpSearchableListPage._filtered`).

📊 **Impact:** In a synthetic local benchmark of 1,000 iterations over 10,000 rows (run via a temporary script in the sandbox using relative imports), elapsed time decreased from ~1050 ms to ~429 ms, a ~59% reduction in execution time, along with a drastic decrease in temporary `String` object allocations and associated GC pauses.

🔬 **Measurement:** Verify by running the unit tests `test/services/side_panel/side_panel_row_filter_test.dart` and interacting with the search field in the side panel.

---
*PR created automatically by Jules for task [11984011875718937873](https://jules.google.com/task/11984011875718937873) started by @silvio-l*