### PR TITLE
🎨 Palette: Make Find & Replace bar buttons keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@ instead — that manual fix is the actual reference implementation.
 and (b) isn't already covered by another explicit `Semantics(button: true)`. If the row already has a
 dedicated icon button doing the same action, wrapping the row is redundant — either extend the existing
 button's hit area, or remove the now-duplicate inner button, but never both.
+## 2026-08-28 - Keyboard focus on custom icon buttons
+**Learning:** Custom interactive elements built with `GestureDetector` inside an `AnimatedContainer` lack keyboard focus support. Wrapping them in `InkWell` with a shared `FocusNode` and `WpFocusRing` solves this. To prevent `InkWell`'s default visual feedback from clashing with the existing `AnimatedContainer`'s hover state, set the `InkWell`'s `focusColor`, `hoverColor`, `splashColor`, and `highlightColor` all to `Colors.transparent`.
+**Action:** Use `InkWell` with transparent interaction colors and a shared `FocusNode` wrapped in `WpFocusRing` when converting custom `GestureDetector` buttons to support keyboard accessibility without altering their visual hover styles.

--- a/lib/widgets/find_replace_bar.dart
+++ b/lib/widgets/find_replace_bar.dart
@@ -20,6 +20,7 @@ import '../core/theme/colors.dart';
 import '../core/theme/tokens.dart';
 import 'find_replace.dart';
 import 'wp_text_field.dart';
+import 'wp_focus_ring.dart';
 
 /// Height-capped icon button used for the bar's five compact actions.
 ///
@@ -48,6 +49,13 @@ class _BarIconButton extends StatefulWidget {
 
 class _BarIconButtonState extends State<_BarIconButton> {
   bool _hovered = false;
+  final _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,29 +66,43 @@ class _BarIconButtonState extends State<_BarIconButton> {
         ? WpColors.accent
         : WpColors.textMuted;
 
-    return Semantics(
-      label: widget.label,
-      button: true,
-      enabled: enabled,
-      child: Tooltip(
-        message: widget.label,
-        waitDuration: const Duration(milliseconds: 400),
-        child: MouseRegion(
-          cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
-          onEnter: (_) => setState(() => _hovered = true),
-          onExit: (_) => setState(() => _hovered = false),
-          child: GestureDetector(
-            onTap: widget.onTap,
-            child: AnimatedContainer(
-              duration: WpMotion.durationFor(context, WpMotion.hoverOut),
-              padding: const EdgeInsets.all(WpSpacing.xs),
-              decoration: BoxDecoration(
-                color: _hovered && enabled
-                    ? WpColors.accent.withValues(alpha: 0.12)
-                    : null,
+    return MergeSemantics(
+      child: Semantics(
+        label: widget.label,
+        button: true,
+        enabled: enabled,
+        child: Tooltip(
+          message: widget.label,
+          waitDuration: const Duration(milliseconds: 400),
+          child: MouseRegion(
+            cursor: enabled
+                ? SystemMouseCursors.click
+                : SystemMouseCursors.basic,
+            onEnter: (_) => setState(() => _hovered = true),
+            onExit: (_) => setState(() => _hovered = false),
+            child: WpFocusRing(
+              focusNode: _focusNode,
+              radius: WpRadius.sm,
+              child: InkWell(
+                onTap: widget.onTap,
+                focusNode: _focusNode,
                 borderRadius: WpRadius.borderSm,
+                focusColor: Colors.transparent,
+                hoverColor: Colors.transparent,
+                splashColor: Colors.transparent,
+                highlightColor: Colors.transparent,
+                child: AnimatedContainer(
+                  duration: WpMotion.durationFor(context, WpMotion.hoverOut),
+                  padding: const EdgeInsets.all(WpSpacing.xs),
+                  decoration: BoxDecoration(
+                    color: _hovered && enabled
+                        ? WpColors.accent.withValues(alpha: 0.12)
+                        : null,
+                    borderRadius: WpRadius.borderSm,
+                  ),
+                  child: Icon(widget.icon, size: 14, color: color),
+                ),
               ),
-              child: Icon(widget.icon, size: 14, color: color),
             ),
           ),
         ),


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility (tab navigation and enter activation) to the custom icon buttons in the Find & Replace bar.
🎯 **Why:** Previously, these buttons used a bare `GestureDetector`, which doesn't natively support keyboard focus. Screen reader and keyboard-only users could not tab to or activate the find previous/next and replace actions.
♿ **Accessibility:** Replaced `GestureDetector` with an `InkWell` wrapped in `WpFocusRing` (and `MergeSemantics`), binding them with a shared `FocusNode` to ensure screen readers announce them properly and keyboard focus is visually evident using the project's standard focus ring style. Interaction colors on the `InkWell` were nulled out to prevent conflicts with the existing custom hover animations.

---
*PR created automatically by Jules for task [3028183987818503189](https://jules.google.com/task/3028183987818503189) started by @silvio-l*