### PR TITLE
⚡ Bolt: [performance] Prevent unnecessary string allocations in STT exit classifier

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@ was already rejected, because rejected PRs never touch `dev`.
 ## 2024-05-18 - Case-insensitive filtering in Dart tight loops
 **Learning:** Using `String.toLowerCase()` inside a tight `where` loop in Dart allocates a new String for every item evaluated. In lists of strings like search results or tag lists, this creates massive GC pressure.
 **Action:** Use a precompiled `RegExp` with `caseSensitive: false` before the loop, and use `searchRegex.hasMatch(item)` inside the loop instead. Note: Do not apply to `WpSearchableListPage._filtered`.
+## 2024-05-14 - String Allocation in Text Matching
+**Learning:** In Dart tight loops, calling `.toLowerCase().contains()` against a needle variable allocates a new lowercased copy of the target string on every single iteration.
+**Action:** When filtering or matching text iteratively where Unicode edge cases (e.g., Turkish 'İ') aren't strictly an issue, precompile a case-insensitive `RegExp(RegExp.escape(needle), caseSensitive: false)` before the loop and use `.hasMatch(line)` inside.

--- a/lib/services/stt/stt_exit_classifier.dart
+++ b/lib/services/stt/stt_exit_classifier.dart
@@ -74,8 +74,11 @@ const String _failedToOpenMarker = 'failed to open';
 /// when the server explicitly reports it could not open the model file. Pure;
 /// no side-effects.
 ModelLoadFailureCause classifyModelLoadFailure(Iterable<String> stderrLines) {
+  // ⚡ Bolt: Precompile case-insensitive RegExp before the loop to avoid
+  // allocating a lowercased copy of each stderr line.
+  final regex = RegExp(RegExp.escape(_failedToOpenMarker), caseSensitive: false);
   for (final line in stderrLines) {
-    if (line.toLowerCase().contains(_failedToOpenMarker)) {
+    if (regex.hasMatch(line)) {
       return ModelLoadFailureCause.fileUnreadable;
     }
   }


### PR DESCRIPTION
**💡 What:** Replaced the `.toLowerCase().contains(_failedToOpenMarker)` text match inside the tight `stderrLines` loop of `classifyModelLoadFailure` with a pre-compiled `RegExp(RegExp.escape(_failedToOpenMarker), caseSensitive: false)`.

**🎯 Why:** In Dart, calling `.toLowerCase()` on a string creates a new string allocation in memory. Doing this inside an iterative loop (like parsing all stderr lines from the STT subprocess) generates hundreds of temporary string objects unnecessarily, which causes completely avoidable Garbage Collection (GC) pressure in long error traces. 

**📊 Impact:** Eliminates O(N) lowercased string allocations during STT subprocess crash handling (where N is the number of stderr lines). The memory impact drops to O(1) by reusing the pre-compiled case-insensitive regex.

**🔬 Measurement:** Verified against existing `stt_exit_classifier_test.dart` cases via isolated testing script to ensure behavioral equivalence (it strictly maintains the lower-cased substring match property).

---
*PR created automatically by Jules for task [15023561886612438118](https://jules.google.com/task/15023561886612438118) started by @silvio-l*