### PR TITLE
🎨 Palette: Make side panel controls keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@ button's hit area, or remove the now-duplicate inner button, but never both.
 ## 2026-10-23 - Keyboard focus on window control buttons
 **Learning:** Sub-components like custom window control buttons (`_WindowButton`, `_MaximizeButton`) in standard title bars using `GestureDetector` inside an `AnimatedContainer` need `InkWell` combined with a `WpFocusRing` sharing a `FocusNode` to be accessible via keyboard.
 **Action:** When updating such custom buttons to support keyboard accessibility, replace `GestureDetector` with an `InkWell` wrapped in `WpFocusRing`, and set the `InkWell` interaction colors to transparent so they don't visually clash with the `AnimatedContainer`'s existing styling logic (which can be extended to listen to `FocusNode.hasFocus`).
+
+## 2023-11-09 - Keyboard accessibility on Side Panel interactive tabs and close buttons
+**Learning:** Just like window control buttons or history detail panels, custom side panel segmented controls (`_SidePanelTab`) and buttons (`_CloseButton`) that rely on an `AnimatedContainer` with a bare `GestureDetector` lack keyboard accessibility.
+**Action:** When updating Side Panel custom components to support keyboard focus and activation (Space/Enter), replace the `GestureDetector` with an `InkWell` wrapped in a `WpFocusRing` passing the same `FocusNode`. Ensure `focusColor`, `hoverColor`, `splashColor`, and `highlightColor` are set to `Colors.transparent` on the `InkWell` to not visually clash with the `AnimatedContainer`'s existing styling logic.

--- a/lib/widgets/side_panel/side_panel_view.dart
+++ b/lib/widgets/side_panel/side_panel_view.dart
@@ -341,6 +341,13 @@ class _SidePanelTab extends StatefulWidget {
 
 class _SidePanelTabState extends State<_SidePanelTab> {
   bool _isHovered = false;
+  final FocusNode _focusNode = FocusNode(debugLabel: 'SidePanelTab');
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -353,39 +360,49 @@ class _SidePanelTabState extends State<_SidePanelTab> {
         cursor: SystemMouseCursors.click,
         onEnter: (_) => setState(() => _isHovered = true),
         onExit: (_) => setState(() => _isHovered = false),
-        child: GestureDetector(
-          onTap: widget.onTap,
-          child: AnimatedContainer(
-            duration: WpMotion.durationFor(
-              context,
-              isActive ? WpMotion.hoverIn : WpMotion.hoverOut,
-            ),
-            curve: WpMotion.defaultCurve,
-            height: 28,
-            decoration: BoxDecoration(
-              color: widget.isSelected
-                  ? WpColors.accentActiveFill
-                  : _isHovered
-                  ? WpColors.hover
-                  : WpColors.hoverTransparent,
-              borderRadius: WpRadius.borderSm,
-              // Never null -- animates its alpha, so the selection edge
-              // fades instead of flashing (see wp_list_tile_surface.dart).
-              border: Border.all(
-                color: widget.isSelected
-                    ? WpColors.accentBorder20
-                    : const Color(0x006FDDF0),
-                width: 1,
+        child: WpFocusRing(
+          focusNode: _focusNode,
+          radius: WpRadius.sm,
+          child: InkWell(
+            onTap: widget.onTap,
+            focusNode: _focusNode,
+            borderRadius: WpRadius.borderSm,
+            focusColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            child: AnimatedContainer(
+              duration: WpMotion.durationFor(
+                context,
+                isActive ? WpMotion.hoverIn : WpMotion.hoverOut,
               ),
-            ),
-            child: Icon(
-              widget.icon,
-              size: WpIconSize.md,
-              color: widget.isSelected
-                  ? WpColors.accent
-                  : _isHovered
-                  ? WpColors.textSecondary
-                  : WpColors.textMuted,
+              curve: WpMotion.defaultCurve,
+              height: 28,
+              decoration: BoxDecoration(
+                color: widget.isSelected
+                    ? WpColors.accentActiveFill
+                    : _isHovered
+                    ? WpColors.hover
+                    : WpColors.hoverTransparent,
+                borderRadius: WpRadius.borderSm,
+                // Never null -- animates its alpha, so the selection edge
+                // fades instead of flashing (see wp_list_tile_surface.dart).
+                border: Border.all(
+                  color: widget.isSelected
+                      ? WpColors.accentBorder20
+                      : const Color(0x006FDDF0),
+                  width: 1,
+                ),
+              ),
+              child: Icon(
+                widget.icon,
+                size: WpIconSize.md,
+                color: widget.isSelected
+                    ? WpColors.accent
+                    : _isHovered
+                    ? WpColors.textSecondary
+                    : WpColors.textMuted,
+              ),
             ),
           ),
         ),
@@ -406,6 +423,13 @@ class _CloseButton extends StatefulWidget {
 
 class _CloseButtonState extends State<_CloseButton> {
   bool _isHovered = false;
+  final FocusNode _focusNode = FocusNode(debugLabel: 'CloseButton');
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -416,24 +440,34 @@ class _CloseButtonState extends State<_CloseButton> {
         cursor: SystemMouseCursors.click,
         onEnter: (_) => setState(() => _isHovered = true),
         onExit: (_) => setState(() => _isHovered = false),
-        child: GestureDetector(
-          onTap: widget.onTap,
-          child: AnimatedContainer(
-            duration: WpMotion.durationFor(
-              context,
-              _isHovered ? WpMotion.hoverIn : WpMotion.hoverOut,
-            ),
-            curve: WpMotion.defaultCurve,
-            width: 28,
-            height: 28,
-            decoration: BoxDecoration(
-              color: _isHovered ? WpColors.hover : WpColors.hoverTransparent,
-              borderRadius: WpRadius.borderSm,
-            ),
-            child: Icon(
-              LucideIcons.x,
-              size: WpIconSize.md,
-              color: _isHovered ? WpColors.textPrimary : WpColors.textMuted,
+        child: WpFocusRing(
+          focusNode: _focusNode,
+          radius: WpRadius.sm,
+          child: InkWell(
+            onTap: widget.onTap,
+            focusNode: _focusNode,
+            borderRadius: WpRadius.borderSm,
+            focusColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            child: AnimatedContainer(
+              duration: WpMotion.durationFor(
+                context,
+                _isHovered ? WpMotion.hoverIn : WpMotion.hoverOut,
+              ),
+              curve: WpMotion.defaultCurve,
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: _isHovered ? WpColors.hover : WpColors.hoverTransparent,
+                borderRadius: WpRadius.borderSm,
+              ),
+              child: Icon(
+                LucideIcons.x,
+                size: WpIconSize.md,
+                color: _isHovered ? WpColors.textPrimary : WpColors.textMuted,
+              ),
             ),
           ),
         ),

--- a/lib/widgets/side_panel/side_panel_view.dart
+++ b/lib/widgets/side_panel/side_panel_view.dart
@@ -6,6 +6,7 @@ import '../../core/theme/colors.dart';
 import '../../core/theme/tokens.dart';
 import '../../services/side_panel/side_panel_row_filter.dart';
 import '../../services/side_panel/side_panel_snapshot.dart';
+import '../wp_focus_ring.dart';
 import '../wp_search_field.dart';
 import 'side_panel_row_tile.dart';
 


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the Side Panel tabs and close buttons.
🎯 Why: Previously, these custom controls used bare `GestureDetector` instances, rendering them inaccessible to users who rely on keyboard navigation (no focus state, cannot activate with Space/Enter).
📸 Before/After: Visuals for mouse users remain completely unchanged, as the `InkWell` is configured with transparent feedback colors to prevent clashes with the `AnimatedContainer` logic. Screen reader logic and semantics are unchanged. Keyboard users now receive correct focus indication via `WpFocusRing`.
♿ Accessibility: Ensures custom button controls are fully discoverable and operable via keyboard.

---
*PR created automatically by Jules for task [6812456840384375709](https://jules.google.com/task/6812456840384375709) started by @silvio-l*