### PR TITLE
🌱 Sprout: Keep copy and duplicate actions on trashed notes in list view

### DIFF
--- a/.jules/sprout.md
+++ b/.jules/sprout.md
@@ -15,3 +15,7 @@
 ## 2025-03-02 - Add duplicate action to note editor toolbar
 **Learning:** Adding a button to the NoteEditorPanel toolbar for an action (like Duplicate) that is already supported and plumbed through the widget tree (via `onDuplicate` callback) is a low-risk, high-value Sprout task. It exposes existing functionality.
 **Action:** Always verify if an action already has a callback passed into the widget when considering exposing it in the UI. If it does, implementing it is as simple as adding the UI element. When adding a new required field to a mock class (or discovering an existing one was not mocked everywhere), be sure to update all test usages.
+
+## 2025-03-05 - Notes List Tile Trash View Action Consistency
+**Learning:** In WhisPaste, some actions like "Copy" or "Duplicate" on list tiles can be mistakenly hidden in specific modes (like trash view) simply because their layout was isolated inside a conditionally rendered block. This creates a consistency gap with the Detail/Editor panel which successfully shows those actions on trashed items.
+**Action:** When working as Sprout to unify UI actions, verify that standard actions are structurally placed *outside* mutually-exclusive layout blocks (e.g., `isTrashView` conditionals) when they apply to all states.

--- a/lib/features/notes/widgets/notes_list_tile.dart
+++ b/lib/features/notes/widgets/notes_list_tile.dart
@@ -289,26 +289,26 @@ class _NotesListTileState extends State<NotesListTile> {
                         color: textMuted,
                       ),
                     ),
-                    if (!widget.isTrashView) ...[
-                      const SizedBox(width: WpSpacing.xxs),
-                      WpRowActions(
-                        visible: _isHovered || widget.isFocused,
-                        dense: true,
-                        children: [
-                          // loam-ignore: a11y-interactive-semantics – semantics provided in _WpRowActionState.build
+                    const SizedBox(width: WpSpacing.xxs),
+                    WpRowActions(
+                      visible: _isHovered || widget.isFocused,
+                      dense: true,
+                      children: [
+                        // loam-ignore: a11y-interactive-semantics – semantics provided in _WpRowActionState.build
+                        WpRowAction(
+                          icon: LucideIcons.copy,
+                          tooltip: l10n.notesCopy,
+                          onTap: widget.onCopy,
+                          dense: true,
+                        ),
+                        if (widget.onDuplicate case final onDuplicate?)
                           WpRowAction(
-                            icon: LucideIcons.copy,
-                            tooltip: l10n.notesCopy,
-                            onTap: widget.onCopy,
+                            icon: LucideIcons.files,
+                            tooltip: l10n.actionDuplicate,
+                            onTap: onDuplicate,
                             dense: true,
                           ),
-                          if (widget.onDuplicate case final onDuplicate?)
-                            WpRowAction(
-                              icon: LucideIcons.files,
-                              tooltip: l10n.actionDuplicate,
-                              onTap: onDuplicate,
-                              dense: true,
-                            ),
+                        if (!widget.isTrashView)
                           if (!widget.note.isQuickNote)
                             // Setting the mark is an ordinary trailing row action —
                             // revealed on hover/focus like every other one, and
@@ -322,15 +322,7 @@ class _NotesListTileState extends State<NotesListTile> {
                               onTap: widget.onQuickNoteSet,
                               dense: true,
                             ),
-                        ],
-                      ),
-                    ],
-                    if (widget.isTrashView) ...[
-                      const SizedBox(width: WpSpacing.xxs),
-                      WpRowActions(
-                        visible: _isHovered || widget.isFocused,
-                        dense: true,
-                        children: [
+                        if (widget.isTrashView) ...[
                           // loam-ignore: a11y-interactive-semantics – semantics provided in _WpRowActionState.build
                           WpRowAction(
                             // Same restore glyph as the editor toolbar and
@@ -349,8 +341,8 @@ class _NotesListTileState extends State<NotesListTile> {
                             dense: true,
                           ),
                         ],
-                      ),
-                    ],
+                      ],
+                    ),
                   ],
                 ),
                 // Row 2: content preview — hidden when the note is title-only


### PR DESCRIPTION
**🌱 What**
Moved the `copy` and `duplicate` actions outside the `!widget.isTrashView` layout block in `NotesListTile`.

**💡 Why**
This resolves a consistency gap where the `copy` and `duplicate` actions were available on trashed notes within the editor panel, but disappeared from the note list tiles. Copying trashed content is often helpful for salvaging text before permanently deleting a note.

**🧩 Why this is low-risk**
This is purely a layout structuring change inside `NotesListTile`. Both sets of actions were safely merged into a unified `WpRowActions` block. The functionality itself (copying and duplicating) remains completely unchanged.

**🔧 Implementation**
The existing `WpRowAction` blocks for `copy` and `duplicate` were lifted into the root of a newly unified `WpRowActions` layout and are now drawn universally, alongside the specific buttons for trash or live views. 

**✅ Verification**
Manually analyzed `notes_page_test.dart` to ensure no widget tests broke explicitly checking for the absence of these buttons. Formatted the codebase. Code review passed `#Correct#`.

---
*PR created automatically by Jules for task [8203575877045538438](https://jules.google.com/task/8203575877045538438) started by @silvio-l*